### PR TITLE
Add benchmarks for public functions

### DIFF
--- a/metric_name_builder_bench_test.go
+++ b/metric_name_builder_bench_test.go
@@ -1,4 +1,4 @@
-package prometheus
+package otlptranslator
 
 import (
 	"fmt"

--- a/metric_name_builder_bench_test.go
+++ b/metric_name_builder_bench_test.go
@@ -1,0 +1,136 @@
+package prometheus
+
+import (
+	"fmt"
+	"testing"
+
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+func BenchmarkBuildMetricNames(b *testing.B) {
+	metrics := createTestMetrics()
+
+	for _, workerType := range []string{"BuildCompliantMetricName", "BuildMetricName"} {
+		for _, withSuffixes := range []bool{true, false} {
+			b.Run(fmt.Sprintf("%s/withSuffixes=%t", workerType, withSuffixes), func(b *testing.B) {
+				var worker Worker
+				if workerType == "BuildCompliantMetricName" {
+					worker = &BuildCompliantMetricNameWorker{
+						metrics:      metrics,
+						namespace:    "test_namespace",
+						withSuffixes: withSuffixes,
+					}
+				} else {
+					worker = &BuildMetricNameWorker{
+						metrics:      metrics,
+						namespace:    "test_namespace",
+						withSuffixes: withSuffixes,
+					}
+				}
+
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					worker.Work()
+				}
+			})
+		}
+	}
+}
+
+type Worker interface {
+	Work()
+}
+
+type BuildCompliantMetricNameWorker struct {
+	metrics      []pmetric.Metric
+	namespace    string
+	withSuffixes bool
+}
+
+func (w *BuildCompliantMetricNameWorker) Work() {
+	for _, metric := range w.metrics {
+		BuildCompliantMetricName(metric, w.namespace, w.withSuffixes)
+	}
+}
+
+type BuildMetricNameWorker struct {
+	metrics      []pmetric.Metric
+	namespace    string
+	withSuffixes bool
+}
+
+func (w *BuildMetricNameWorker) Work() {
+	for _, metric := range w.metrics {
+		BuildMetricName(metric, w.namespace, w.withSuffixes)
+	}
+}
+
+func createTestMetrics() []pmetric.Metric {
+	metrics := make([]pmetric.Metric, 0)
+
+	// Basic metric with no special characters
+	metric := pmetric.NewMetric()
+	metric.SetName("simple_metric")
+	metric.SetUnit("")
+	metric.SetEmptyGauge()
+	metrics = append(metrics, metric)
+
+	// Counter metric (should get _total suffix)
+	metric = pmetric.NewMetric()
+	metric.SetName("counter_metric")
+	metric.SetUnit("")
+	sum := metric.SetEmptySum()
+	sum.SetIsMonotonic(true)
+	metrics = append(metrics, metric)
+
+	// Metric with unit "1" (should get _ratio suffix for gauge)
+	metric = pmetric.NewMetric()
+	metric.SetName("ratio_metric")
+	metric.SetUnit("1")
+	metric.SetEmptyGauge()
+	metrics = append(metrics, metric)
+
+	// Metric with per-unit notation
+	metric = pmetric.NewMetric()
+	metric.SetName("requests")
+	metric.SetUnit("1/s")
+	metric.SetEmptyGauge()
+	metrics = append(metrics, metric)
+
+	// Metric with special characters
+	metric = pmetric.NewMetric()
+	metric.SetName("metric@with#special$chars")
+	metric.SetUnit("")
+	metric.SetEmptyGauge()
+	metrics = append(metrics, metric)
+
+	// Metric starting with digit
+	metric = pmetric.NewMetric()
+	metric.SetName("123metric")
+	metric.SetUnit("")
+	metric.SetEmptyGauge()
+	metrics = append(metrics, metric)
+
+	// Metric with multiple consecutive underscores
+	metric = pmetric.NewMetric()
+	metric.SetName("metric__with__multiple__underscores")
+	metric.SetUnit("")
+	metric.SetEmptyGauge()
+	metrics = append(metrics, metric)
+
+	// Metric with complex unit
+	metric = pmetric.NewMetric()
+	metric.SetName("memory_usage")
+	metric.SetUnit("MiBy/s")
+	metric.SetEmptyGauge()
+	metrics = append(metrics, metric)
+
+	// Metric with percentage unit
+	metric = pmetric.NewMetric()
+	metric.SetName("cpu_usage")
+	metric.SetUnit("%")
+	metric.SetEmptyGauge()
+	metrics = append(metrics, metric)
+
+	return metrics
+}

--- a/metric_name_builder_bench_test.go
+++ b/metric_name_builder_bench_test.go
@@ -8,46 +8,50 @@ import (
 )
 
 func BenchmarkBuildCompliantMetricName(b *testing.B) {
-	metrics := createTestScenarios()
+	scenarios := createTestScenarios()
 
-	for _, scenario := range metrics {
-		for _, withSuffixes := range []bool{true, false} {
-			b.Run(fmt.Sprintf("%s/withSuffixes=%t", scenario.name, withSuffixes), func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
-					BuildCompliantMetricName(scenario.metric, "test_namespace", withSuffixes)
-				}
-			})
-		}
+	for _, withSuffixes := range []bool{true, false} {
+		b.Run(fmt.Sprintf("withSuffixes=%t", withSuffixes), func(b *testing.B) {
+			for _, scenario := range scenarios {
+				b.Run(scenario.name, func(b *testing.B) {
+					for i := 0; i < b.N; i++ {
+						BuildCompliantMetricName(scenario.metric, "test_namespace", withSuffixes)
+					}
+				})
+			}
+		})
 	}
 }
 
 func BenchmarkBuildMetricName(b *testing.B) {
-	metrics := createTestScenarios()
+	scenarios := createTestScenarios()
 
-	for _, scenario := range metrics {
-		for _, withSuffixes := range []bool{true, false} {
-			b.Run(fmt.Sprintf("%s/withSuffixes=%t", scenario.name, withSuffixes), func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
-					BuildMetricName(scenario.metric, "test_namespace", withSuffixes)
-				}
-			})
-		}
+	for _, withSuffixes := range []bool{true, false} {
+		b.Run(fmt.Sprintf("withSuffixes=%t", withSuffixes), func(b *testing.B) {
+			for _, scenario := range scenarios {
+				b.Run(scenario.name, func(b *testing.B) {
+					for i := 0; i < b.N; i++ {
+						BuildMetricName(scenario.metric, "test_namespace", withSuffixes)
+					}
+				})
+			}
+		})
 	}
 }
 
-type Scenario struct {
+type scenario struct {
 	name   string
 	metric pmetric.Metric
 }
 
-func createTestScenarios() []Scenario {
-	scenarios := make([]Scenario, 0)
+func createTestScenarios() []scenario {
+	scenarios := make([]scenario, 0)
 
 	metric := pmetric.NewMetric()
 	metric.SetName("simple_metric")
 	metric.SetUnit("")
 	metric.SetEmptyGauge()
-	scenarios = append(scenarios, Scenario{
+	scenarios = append(scenarios, scenario{
 		name:   "Basic metric with no special characters",
 		metric: metric,
 	})
@@ -57,7 +61,7 @@ func createTestScenarios() []Scenario {
 	metric.SetUnit("")
 	sum := metric.SetEmptySum()
 	sum.SetIsMonotonic(true)
-	scenarios = append(scenarios, Scenario{
+	scenarios = append(scenarios, scenario{
 		name:   "Counter metric",
 		metric: metric,
 	})
@@ -66,7 +70,7 @@ func createTestScenarios() []Scenario {
 	metric.SetName("ratio_metric")
 	metric.SetUnit("1")
 	metric.SetEmptyGauge()
-	scenarios = append(scenarios, Scenario{
+	scenarios = append(scenarios, scenario{
 		name:   "Gauge ratio metric",
 		metric: metric,
 	})
@@ -75,7 +79,7 @@ func createTestScenarios() []Scenario {
 	metric.SetName("requests")
 	metric.SetUnit("1/s")
 	metric.SetEmptyGauge()
-	scenarios = append(scenarios, Scenario{
+	scenarios = append(scenarios, scenario{
 		name:   "Metric with per-unit suffix notation",
 		metric: metric,
 	})
@@ -84,7 +88,7 @@ func createTestScenarios() []Scenario {
 	metric.SetName("metric@with#special$chars")
 	metric.SetUnit("")
 	metric.SetEmptyGauge()
-	scenarios = append(scenarios, Scenario{
+	scenarios = append(scenarios, scenario{
 		name:   "Metric with special characters",
 		metric: metric,
 	})
@@ -93,7 +97,7 @@ func createTestScenarios() []Scenario {
 	metric.SetName("123metric")
 	metric.SetUnit("")
 	metric.SetEmptyGauge()
-	scenarios = append(scenarios, Scenario{
+	scenarios = append(scenarios, scenario{
 		name:   "Metric starting with digit",
 		metric: metric,
 	})
@@ -102,7 +106,7 @@ func createTestScenarios() []Scenario {
 	metric.SetName("metric__with__multiple__underscores")
 	metric.SetUnit("")
 	metric.SetEmptyGauge()
-	scenarios = append(scenarios, Scenario{
+	scenarios = append(scenarios, scenario{
 		name:   "Metric with multiple underscores",
 		metric: metric,
 	})
@@ -111,7 +115,7 @@ func createTestScenarios() []Scenario {
 	metric.SetName("memory_usage")
 	metric.SetUnit("MiBy/s")
 	metric.SetEmptyGauge()
-	scenarios = append(scenarios, Scenario{
+	scenarios = append(scenarios, scenario{
 		name:   "Metric with complex unit",
 		metric: metric,
 	})

--- a/normalize_label_bench_test.go
+++ b/normalize_label_bench_test.go
@@ -3,43 +3,43 @@ package otlptranslator
 import "testing"
 
 var labelBenchmarkInputs = []struct {
-	name string
+	name  string
 	label string
 }{
 	{
-		name: "empty label",
+		name:  "empty label",
 		label: "",
 	},
 	{
-		name: "label with colons",
+		name:  "label with colons",
 		label: "label:with:colons",
 	},
 	{
-		name: "label with capital letters",
+		name:  "label with capital letters",
 		label: "LabelWithCapitalLetters",
 	},
 	{
-		name: "label with special characters",
+		name:  "label with special characters",
 		label: "label!with&special$chars)",
 	},
 	{
-		name: "label with foreign characters",
+		name:  "label with foreign characters",
 		label: "label_with_foreign_characters_字符",
 	},
 	{
-		name: "label with dots",
+		name:  "label with dots",
 		label: "label.with.dots",
 	},
 	{
-		name: "label starting with digits",
+		name:  "label starting with digits",
 		label: "123label",
 	},
 	{
-		name: "label starting with underscores",
+		name:  "label starting with underscores",
 		label: "_label_starting_with_underscore",
 	},
 	{
-		name: "label starting with 2 underscores",
+		name:  "label starting with 2 underscores",
 		label: "__label_starting_with_2underscores",
 	},
 }

--- a/normalize_label_bench_test.go
+++ b/normalize_label_bench_test.go
@@ -2,22 +2,54 @@ package prometheus
 
 import "testing"
 
-var labelBenchmarkInputs = []string{
-	"",
-	"label:with:colons",
-	"LabelWithCapitalLetters",
-	"label!with&special$chars)",
-	"label_with_foreign_characters_字符",
-	"label.with.dots",
-	"123label",
-	"_label_starting_with_underscore",
-	"__label_starting_with_2underscores",
+var labelBenchmarkInputs = []struct {
+	name string
+	label string
+}{
+	{
+		name: "empty label",
+		label: "",
+	},
+	{
+		name: "label with colons",
+		label: "label:with:colons",
+	},
+	{
+		name: "label with capital letters",
+		label: "LabelWithCapitalLetters",
+	},
+	{
+		name: "label with special characters",
+		label: "label!with&special$chars)",
+	},
+	{
+		name: "label with foreign characters",
+		label: "label_with_foreign_characters_字符",
+	},
+	{
+		name: "label with dots",
+		label: "label.with.dots",
+	},
+	{
+		name: "label starting with digits",
+		label: "123label",
+	},
+	{
+		name: "label starting with underscores",
+		label: "_label_starting_with_underscore",
+	},
+	{
+		name: "label starting with 2 underscores",
+		label: "__label_starting_with_2underscores",
+	},
 }
 
 func BenchmarkNormalizeLabel(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		for _, input := range labelBenchmarkInputs {
-			NormalizeLabel(input)
-		}
+	for _, input := range labelBenchmarkInputs {
+		b.Run(input.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				NormalizeLabel(input.label)
+			}
+		})
 	}
 }

--- a/normalize_label_bench_test.go
+++ b/normalize_label_bench_test.go
@@ -1,4 +1,4 @@
-package prometheus
+package otlptranslator
 
 import "testing"
 

--- a/normalize_label_bench_test.go
+++ b/normalize_label_bench_test.go
@@ -1,0 +1,23 @@
+package prometheus
+
+import "testing"
+
+var labelBenchmarkInputs = []string{
+	"",
+	"label:with:colons",
+	"LabelWithCapitalLetters",
+	"label!with&special$chars)",
+	"label_with_foreign_characters_字符",
+	"label.with.dots",
+	"123label",
+	"_label_starting_with_underscore",
+	"__label_starting_with_2underscores",
+}
+
+func BenchmarkNormalizeLabel(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for _, input := range labelBenchmarkInputs {
+			NormalizeLabel(input)
+		}
+	}
+}


### PR DESCRIPTION
This PR adds benchmarks for us to work with in future optimizations.

This is pre-requisite for future optimization ideas:

* Replace regex with boolean comparisons, like `if (rune > 0 && rune < 9) || (rune > a && rune < Z)`
* Switching function signature from OTel large objects to smaller strings