### PR TITLE
Use adapted golangci-lint config from Prometheus

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -36,4 +36,4 @@ jobs:
         uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
         with:
           args: --verbose
-          version: v1.64.6
+          version: v1.64.7

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,11 +1,123 @@
+run:
+  timeout: 15m
+
+output:
+  sort-results: true
+
 linters:
+  # Keep this list sorted alphabetically
   enable:
+    - depguard
+    - errorlint
+    - exptostd
+    - gocritic
+    - godot
+    - gofumpt
     - goimports
+    - loggercheck
     - misspell
+    - nilnesserr
+    # TODO: Enable once https://github.com/golangci/golangci-lint/issues/3228 is fixed.
+    # - nolintlint
+    - perfsprint
+    - predeclared
     - revive
+    - sloglint
+    - testifylint
+    - unconvert
+    - unused
+    - usestdlibvars
+    - whitespace
 
 issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+  # The default exclusions are too aggressive. For one, they
+  # essentially disable any linting on doc comments. We disable
+  # default exclusions here and add exclusions fitting our codebase
+  # further down.
+  exclude-use-default: false
   exclude-rules:
+    - linters:
+        - errcheck
+      # Taken from the default exclusions (that are otherwise disabled above).
+      text: Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
     - path: _test.go
       linters:
         - errcheck
+    - linters:
+        - godot
+      source: "^// ==="
+    - linters:
+        - perfsprint
+      text: "fmt.Sprintf can be replaced with string concatenation"
+linters-settings:
+  depguard:
+    rules:
+      main:
+        deny:
+          - pkg: "sync/atomic"
+            desc: "Use go.uber.org/atomic instead of sync/atomic"
+          - pkg: "github.com/stretchr/testify/assert"
+            desc: "Use github.com/stretchr/testify/require instead of github.com/stretchr/testify/assert"
+          - pkg: "io/ioutil"
+            desc: "Use corresponding 'os' or 'io' functions instead."
+          - pkg: "regexp"
+            desc: "Use github.com/grafana/regexp instead of regexp"
+          - pkg: "github.com/pkg/errors"
+            desc: "Use 'errors' or 'fmt' instead of github.com/pkg/errors"
+          - pkg: "golang.org/x/exp/slices"
+            desc: "Use 'slices' instead."
+  goimports:
+    local-prefixes: github.com/prometheus/otlptranslator
+  gofumpt:
+    extra-rules: true
+  perfsprint:
+     # Optimizes `fmt.Errorf`.
+    errorf: true
+  revive:
+    # By default, revive will enable only the linting rules that are named in the configuration file.
+    # So, it's needed to explicitly enable all required rules here.
+    rules:
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md
+      - name: blank-imports
+      - name: comment-spacings
+      - name: context-as-argument
+        arguments:
+          # Allow functions with test or bench signatures.
+          - allowTypesBefore: "*testing.T,testing.TB"
+      - name: context-keys-type
+      - name: dot-imports
+      - name: early-return
+        arguments:
+          - "preserveScope"
+      # A lot of false positives: incorrectly identifies channel draining as "empty code block".
+      # See https://github.com/mgechev/revive/issues/386
+      - name: empty-block
+        disabled: true
+      - name: error-naming
+      - name: error-return
+      - name: error-strings
+      - name: errorf
+      - name: exported
+      - name: increment-decrement
+      - name: indent-error-flow
+        arguments:
+          - "preserveScope"
+      - name: range
+      - name: receiver-naming
+      - name: redefines-builtin-id
+      - name: superfluous-else
+        arguments:
+          - "preserveScope"
+      - name: time-naming
+      - name: unexported-return
+      - name: unreachable-code
+      - name: unused-parameter
+      - name: var-declaration
+      - name: var-naming
+  testifylint:
+    disable:
+      - float-compare
+      - go-require
+    enable-all: true

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/prometheus/otlptranslator
 go 1.23.0
 
 require (
+	github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/pdata v1.28.1
 )

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc h1:GN2Lv3MGO7AS6PrRoT6yV5+wkrOpcszoIsO4+4ds248=
+github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc/go.mod h1:+JKpmjMGhpgPL+rXZ5nsZieVzvarn86asRlBg4uNGnk=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/metric_name_builder.go
+++ b/metric_name_builder.go
@@ -20,11 +20,11 @@
 package otlptranslator
 
 import (
-	"regexp"
 	"slices"
 	"strings"
 	"unicode"
 
+	"github.com/grafana/regexp"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
@@ -69,8 +69,8 @@ var unitMap = map[string]string{
 	"%":   "percent",
 }
 
-// The map that translates the "per" unit
-// Example: s => per second (singular)
+// The map that translates the "per" unit.
+// Example: s => per second (singular).
 var perUnitMap = map[string]string{
 	"s":  "second",
 	"m":  "minute",
@@ -207,8 +207,8 @@ func cleanUpUnit(unit string) string {
 	), "_")
 }
 
-// Retrieve the Prometheus "basic" unit corresponding to the specified "basic" unit
-// Returns the specified unit if not found in unitMap
+// Retrieve the Prometheus "basic" unit corresponding to the specified "basic" unit.
+// Returns the specified unit if not found in unitMap.
 func unitMapGetOrDefault(unit string) string {
 	if promUnit, ok := unitMap[unit]; ok {
 		return promUnit
@@ -216,8 +216,8 @@ func unitMapGetOrDefault(unit string) string {
 	return unit
 }
 
-// Retrieve the Prometheus "per" unit corresponding to the specified "per" unit
-// Returns the specified unit if not found in perUnitMap
+// Retrieve the Prometheus "per" unit corresponding to the specified "per" unit.
+// Returns the specified unit if not found in perUnitMap.
 func perUnitMapGetOrDefault(perUnit string) string {
 	if promPerUnit, ok := perUnitMap[perUnit]; ok {
 		return promPerUnit
@@ -225,7 +225,7 @@ func perUnitMapGetOrDefault(perUnit string) string {
 	return perUnit
 }
 
-// Remove the specified value from the slice
+// Remove the specified value from the slice.
 func removeItem(slice []string, value string) []string {
 	newSlice := make([]string, 0, len(slice))
 	for _, sliceEntry := range slice {
@@ -262,7 +262,7 @@ func BuildMetricName(metric pmetric.Metric, namespace string, addMetricSuffixes 
 
 		// Append _total for Counters
 		if metric.Type() == pmetric.MetricTypeSum && metric.Sum().IsMonotonic() {
-			metricName = metricName + "_total"
+			metricName += "_total"
 		}
 
 		// Append _ratio for metrics with unit "1"
@@ -271,7 +271,7 @@ func BuildMetricName(metric pmetric.Metric, namespace string, addMetricSuffixes 
 		// Until these issues have been fixed, we're appending `_ratio` for gauges ONLY
 		// Theoretically, counters could be ratios as well, but it's absurd (for mathematical reasons)
 		if metric.Unit() == "1" && metric.Type() == pmetric.MetricTypeGauge {
-			metricName = metricName + "_ratio"
+			metricName += "_ratio"
 		}
 	}
 	return metricName

--- a/normalize_label.go
+++ b/normalize_label.go
@@ -24,7 +24,7 @@ import (
 	"unicode"
 )
 
-// Normalizes the specified label to follow Prometheus label names standard.
+// NormalizeLabel normalizes the specified label to follow Prometheus label names standard.
 //
 // See rules at https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels.
 //

--- a/strconv.go
+++ b/strconv.go
@@ -20,7 +20,7 @@
 package otlptranslator
 
 import (
-	"regexp"
+	"github.com/grafana/regexp"
 )
 
 var invalidLabelCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)

--- a/testutils_test.go
+++ b/testutils_test.go
@@ -26,15 +26,13 @@ import (
 var ilm pmetric.ScopeMetrics
 
 func init() {
-
 	metrics := pmetric.NewMetrics()
 	resourceMetrics := metrics.ResourceMetrics().AppendEmpty()
 	ilm = resourceMetrics.ScopeMetrics().AppendEmpty()
-
 }
 
-// Returns a new Metric of type "Gauge" with specified name and unit
-func createGauge(name string, unit string) pmetric.Metric {
+// Returns a new Metric of type "Gauge" with specified name and unit.
+func createGauge(name, unit string) pmetric.Metric {
 	gauge := ilm.Metrics().AppendEmpty()
 	gauge.SetName(name)
 	gauge.SetUnit(unit)
@@ -42,8 +40,8 @@ func createGauge(name string, unit string) pmetric.Metric {
 	return gauge
 }
 
-// Returns a new Metric of type Monotonic Sum with specified name and unit
-func createCounter(name string, unit string) pmetric.Metric {
+// Returns a new Metric of type Monotonic Sum with specified name and unit.
+func createCounter(name, unit string) pmetric.Metric {
 	counter := ilm.Metrics().AppendEmpty()
 	counter.SetEmptySum().SetIsMonotonic(true)
 	counter.SetName(name)


### PR DESCRIPTION
Use adapted golangci-lint config from Prometheus, and fix its findings.