### PR TITLE
Optimize NormalizeLabel with strings.Builder

### DIFF
--- a/strconv.go
+++ b/strconv.go
@@ -20,10 +20,8 @@
 package otlptranslator
 
 import (
-	"github.com/grafana/regexp"
+	"strings"
 )
-
-var invalidLabelCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
 
 // sanitizeLabelName replaces any characters not valid according to the
 // classical Prometheus label naming scheme with an underscore.
@@ -31,5 +29,14 @@ var invalidLabelCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
 // not starting with a digit 0-9), and hence should only be used if the label
 // name is prefixed with a known valid string.
 func sanitizeLabelName(name string) string {
-	return invalidLabelCharRE.ReplaceAllString(name, "_")
+	var b strings.Builder
+	b.Grow(len(name))
+	for _, r := range name {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		} else {
+			b.WriteRune('_')
+		}
+	}
+	return b.String()
 }


### PR DESCRIPTION
Optimization for building Normalized labels. Benchmark results:

```
benchstat main.txt no-regexp.txt no-regex-with-stringsBuilder.txt 
goos: darwin
goarch: arm64
pkg: github.com/prometheus/otlptranslator
cpu: Apple M2 Pro
                                                   │   main.txt   │           no-regexp.txt            │  no-regex-with-stringsBuilder.txt  │
                                                   │    sec/op    │    sec/op     vs base              │   sec/op     vs base               │
NormalizeLabel/empty_label-2                          1.963n ± 2%    1.921n ± 2%  -2.09% (p=0.015 n=6)   1.930n ± 2%        ~ (p=0.093 n=6)
NormalizeLabel/label_with_colons-2                   107.95n ± 2%   109.95n ± 2%       ~ (p=0.071 n=6)   61.94n ± 0%  -42.63% (p=0.002 n=6)
NormalizeLabel/label_with_capital_letters-2          141.40n ± 1%   142.55n ± 3%       ~ (p=0.149 n=6)   90.55n ± 2%  -35.96% (p=0.002 n=6)
NormalizeLabel/label_with_special_characters-2       152.50n ± 1%   153.90n ± 1%  +0.92% (p=0.009 n=6)   86.06n ± 1%  -43.57% (p=0.002 n=6)
NormalizeLabel/label_with_foreign_characters-2        201.3n ± 1%    203.6n ± 1%  +1.12% (p=0.026 n=6)   117.3n ± 2%  -41.70% (p=0.002 n=6)
NormalizeLabel/label_with_dots-2                      99.95n ± 1%    95.87n ± 4%       ~ (p=0.065 n=6)   56.82n ± 1%  -43.15% (p=0.002 n=6)
NormalizeLabel/label_starting_with_digits-2           81.94n ± 1%    80.90n ± 3%       ~ (p=0.065 n=6)   59.68n ± 1%  -27.17% (p=0.002 n=6)
NormalizeLabel/label_starting_with_underscores-2      211.4n ± 0%    209.9n ± 2%       ~ (p=0.461 n=6)   128.8n ± 0%  -39.10% (p=0.002 n=6)
NormalizeLabel/label_starting_with_2_underscores-2    221.8n ± 1%    219.7n ± 2%       ~ (p=0.132 n=6)   112.2n ± 1%  -49.41% (p=0.002 n=6)
geomean                                               89.08n         88.63n       -0.50%                 55.93n       -37.21%

                                                   │   main.txt    │            no-regexp.txt            │  no-regex-with-stringsBuilder.txt   │
                                                   │     B/op      │    B/op      vs base                │    B/op     vs base                 │
NormalizeLabel/empty_label-2                          0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=6) ¹   0.000 ± 0%        ~ (p=1.000 n=6) ¹
NormalizeLabel/label_with_colons-2                   104.00 ± 0%     104.00 ± 0%       ~ (p=1.000 n=6) ¹   24.00 ± 0%  -76.92% (p=0.002 n=6)
NormalizeLabel/label_with_capital_letters-2          128.00 ± 0%     128.00 ± 0%       ~ (p=1.000 n=6) ¹   24.00 ± 0%  -81.25% (p=0.002 n=6)
NormalizeLabel/label_with_special_characters-2       144.00 ± 0%     144.00 ± 0%       ~ (p=1.000 n=6) ¹   32.00 ± 0%  -77.78% (p=0.002 n=6)
NormalizeLabel/label_with_foreign_characters-2       192.00 ± 0%     192.00 ± 0%       ~ (p=1.000 n=6) ¹   48.00 ± 0%  -75.00% (p=0.002 n=6)
NormalizeLabel/label_with_dots-2                      88.00 ± 0%      88.00 ± 0%       ~ (p=1.000 n=6) ¹   16.00 ± 0%  -81.82% (p=0.002 n=6)
NormalizeLabel/label_starting_with_digits-2           64.00 ± 0%      64.00 ± 0%       ~ (p=1.000 n=6) ¹   24.00 ± 0%  -62.50% (p=0.002 n=6)
NormalizeLabel/label_starting_with_underscores-2     224.00 ± 0%     224.00 ± 0%       ~ (p=1.000 n=6) ¹   80.00 ± 0%  -64.29% (p=0.002 n=6)
NormalizeLabel/label_starting_with_2_underscores-2   192.00 ± 0%     192.00 ± 0%       ~ (p=1.000 n=6) ¹   48.00 ± 0%  -75.00% (p=0.002 n=6)
geomean                                                          ²                +0.00%               ²               -70.97%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                                   │   main.txt   │           no-regexp.txt            │  no-regex-with-stringsBuilder.txt   │
                                                   │  allocs/op   │ allocs/op   vs base                │ allocs/op   vs base                 │
NormalizeLabel/empty_label-2                         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹   0.000 ± 0%        ~ (p=1.000 n=6) ¹
NormalizeLabel/label_with_colons-2                   2.000 ± 0%     2.000 ± 0%       ~ (p=1.000 n=6) ¹   1.000 ± 0%  -50.00% (p=0.002 n=6)
NormalizeLabel/label_with_capital_letters-2          2.000 ± 0%     2.000 ± 0%       ~ (p=1.000 n=6) ¹   1.000 ± 0%  -50.00% (p=0.002 n=6)
NormalizeLabel/label_with_special_characters-2       2.000 ± 0%     2.000 ± 0%       ~ (p=1.000 n=6) ¹   1.000 ± 0%  -50.00% (p=0.002 n=6)
NormalizeLabel/label_with_foreign_characters-2       2.000 ± 0%     2.000 ± 0%       ~ (p=1.000 n=6) ¹   1.000 ± 0%  -50.00% (p=0.002 n=6)
NormalizeLabel/label_with_dots-2                     2.000 ± 0%     2.000 ± 0%       ~ (p=1.000 n=6) ¹   1.000 ± 0%  -50.00% (p=0.002 n=6)
NormalizeLabel/label_starting_with_digits-2          3.000 ± 0%     3.000 ± 0%       ~ (p=1.000 n=6) ¹   2.000 ± 0%  -33.33% (p=0.002 n=6)
NormalizeLabel/label_starting_with_underscores-2     3.000 ± 0%     3.000 ± 0%       ~ (p=1.000 n=6) ¹   2.000 ± 0%  -33.33% (p=0.002 n=6)
NormalizeLabel/label_starting_with_2_underscores-2   2.000 ± 0%     2.000 ± 0%       ~ (p=1.000 n=6) ¹   1.000 ± 0%  -50.00% (p=0.002 n=6)
geomean                                                         ²               +0.00%               ²               -42.43%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```


The benchmark is comparing `main` (first column), https://github.com/prometheus/otlptranslator/pull/18 (second column) and this PR (third column)