### PR TITLE
Replace remaining regexps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/prometheus/otlptranslator
 go 1.23.0
 
 require (
-	github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/pdata v1.28.1
 )

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,6 @@ github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc h1:GN2Lv3MGO7AS6PrRoT6yV5+wkrOpcszoIsO4+4ds248=
-github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc/go.mod h1:+JKpmjMGhpgPL+rXZ5nsZieVzvarn86asRlBg4uNGnk=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/metric_name_builder.go
+++ b/metric_name_builder.go
@@ -116,7 +116,7 @@ func BuildCompliantMetricName(metric pmetric.Metric, namespace string, addMetric
 
 var (
 	// Regexp for metric name characters that should be replaced with _.
-	invalidMetricCharRE   = regexp.MustCompile(`[^a-zA-Z0-9:_]`)
+	invalidMetricCharRE   = regexp.MustCompile(`[^a-zA-Z0-9:]`)
 	multipleUnderscoresRE = regexp.MustCompile(`__+`)
 )
 

--- a/metric_name_builder_test.go
+++ b/metric_name_builder_test.go
@@ -218,12 +218,12 @@ func TestBuildCompliantMetricNameWithoutSuffixes(t *testing.T) {
 	require.Equal(t, "system_network_io", BuildCompliantMetricName(createCounter("network.io", "By"), "system", false))
 	require.Equal(t, "system_network_I_O", BuildCompliantMetricName(createCounter("network (I/O)", "By"), "system", false))
 	require.Equal(t, "_3_14_digits", BuildCompliantMetricName(createGauge("3.14 digits", "By"), "", false))
-	require.Equal(t, "envoy__rule_engine_zlib_buf_error", BuildCompliantMetricName(createGauge("envoy__rule_engine_zlib_buf_error", ""), "", false))
+	require.Equal(t, "envoy_rule_engine_zlib_buf_error", BuildCompliantMetricName(createGauge("envoy__rule_engine_zlib_buf_error", ""), "", false))
 	require.Equal(t, ":foo::bar", BuildCompliantMetricName(createGauge(":foo::bar", ""), "", false))
 	require.Equal(t, ":foo::bar", BuildCompliantMetricName(createCounter(":foo::bar", ""), "", false))
 	require.Equal(t, "foo_bar", BuildCompliantMetricName(createGauge("foo.bar", "1"), "", false))
 	require.Equal(t, "system_io", BuildCompliantMetricName(createCounter("system.io", "foo/bar"), "", false))
-	require.Equal(t, "metric_with___foreign_characters", BuildCompliantMetricName(createCounter("metric_with_字符_foreign_characters", ""), "", false))
+	require.Equal(t, "metric_with_foreign_characters", BuildCompliantMetricName(createCounter("metric_with_字符_foreign_characters", ""), "", false))
 }
 
 func TestBuildMetricNameWithSuffixes(t *testing.T) {


### PR DESCRIPTION
Building on top of #20, I've tried to replace the remaining regexps with rune comparisons.

Benchmarks doesn't show any relevant improvements, I'm opening the PR just to show what I've done. Feedback is welcome in case y'all notice something that I've missed.

Benchmark results for `BuildCompliantMetricName` (only function affected by the changes here):
```
arthursens$ benchstat main.txt no-regexp.txt 
goos: darwin
goarch: arm64
pkg: github.com/prometheus/otlptranslator
cpu: Apple M2 Pro
                                                                             │  main.txt   │           no-regexp.txt            │
                                                                             │   sec/op    │    sec/op     vs base              │
BuildMetricName/withSuffixes=true/Basic_metric_with_no_special_characters-2    43.67n ± 3%   42.66n ±  1%  -2.32% (p=0.009 n=6)
BuildMetricName/withSuffixes=true/Counter_metric-2                             66.91n ± 2%   64.72n ±  1%  -3.27% (p=0.002 n=6)
BuildMetricName/withSuffixes=true/Gauge_ratio_metric-2                         88.87n ± 2%   82.18n ±  1%  -7.53% (p=0.002 n=6)
BuildMetricName/withSuffixes=true/Metric_with_per-unit_suffix_notation-2       126.8n ± 7%   119.1n ±  2%  -6.07% (p=0.004 n=6)
BuildMetricName/withSuffixes=true/Metric_with_special_characters-2             46.58n ± 7%   45.20n ±  3%       ~ (p=0.132 n=6)
BuildMetricName/withSuffixes=true/Metric_starting_with_digit-2                 44.07n ± 8%   42.80n ±  2%       ~ (p=0.065 n=6)
BuildMetricName/withSuffixes=true/Metric_with_multiple_underscores-2           46.26n ± 2%   45.37n ±  1%  -1.93% (p=0.041 n=6)
BuildMetricName/withSuffixes=true/Metric_with_complex_unit-2                   158.1n ± 2%   155.0n ±  1%  -1.93% (p=0.002 n=6)
BuildMetricName/withSuffixes=false/Basic_metric_with_no_special_characters-2   24.50n ± 5%   24.16n ±  1%  -1.39% (p=0.002 n=6)
BuildMetricName/withSuffixes=false/Counter_metric-2                            24.53n ± 0%   25.69n ±  4%  +4.73% (p=0.004 n=6)
BuildMetricName/withSuffixes=false/Gauge_ratio_metric-2                        24.54n ± 1%   25.08n ±  5%  +2.18% (p=0.026 n=6)
BuildMetricName/withSuffixes=false/Metric_with_per-unit_suffix_notation-2      23.87n ± 2%   24.30n ±  7%       ~ (p=0.368 n=6)
BuildMetricName/withSuffixes=false/Metric_with_special_characters-2            26.20n ± 1%   26.31n ±  2%       ~ (p=0.818 n=6)
BuildMetricName/withSuffixes=false/Metric_starting_with_digit-2                24.02n ± 1%   23.75n ±  3%       ~ (p=0.132 n=6)
BuildMetricName/withSuffixes=false/Metric_with_multiple_underscores-2          27.42n ± 2%   27.52n ±  6%       ~ (p=0.699 n=6)
BuildMetricName/withSuffixes=false/Metric_with_complex_unit-2                  25.44n ± 3%   24.54n ± 13%       ~ (p=0.180 n=6)
geomean                                                                        41.46n        40.79n        -1.63%

                                                                             │  main.txt  │           no-regexp.txt            │
                                                                             │    B/op    │    B/op     vs base                │
BuildMetricName/withSuffixes=true/Basic_metric_with_no_special_characters-2    48.00 ± 0%   48.00 ± 0%       ~ (p=1.000 n=6) ¹
BuildMetricName/withSuffixes=true/Counter_metric-2                             96.00 ± 0%   96.00 ± 0%       ~ (p=1.000 n=6) ¹
BuildMetricName/withSuffixes=true/Gauge_ratio_metric-2                         112.0 ± 0%   112.0 ± 0%       ~ (p=1.000 n=6) ¹
BuildMetricName/withSuffixes=true/Metric_with_per-unit_suffix_notation-2       120.0 ± 0%   120.0 ± 0%       ~ (p=1.000 n=6) ¹
BuildMetricName/withSuffixes=true/Metric_with_special_characters-2             64.00 ± 0%   64.00 ± 0%       ~ (p=1.000 n=6) ¹
BuildMetricName/withSuffixes=true/Metric_starting_with_digit-2                 40.00 ± 0%   40.00 ± 0%       ~ (p=1.000 n=6) ¹
BuildMetricName/withSuffixes=true/Metric_with_multiple_underscores-2           80.00 ± 0%   80.00 ± 0%       ~ (p=1.000 n=6) ¹
BuildMetricName/withSuffixes=true/Metric_with_complex_unit-2                   176.0 ± 0%   176.0 ± 0%       ~ (p=1.000 n=6) ¹
BuildMetricName/withSuffixes=false/Basic_metric_with_no_special_characters-2   32.00 ± 0%   32.00 ± 0%       ~ (p=1.000 n=6) ¹
BuildMetricName/withSuffixes=false/Counter_metric-2                            32.00 ± 0%   32.00 ± 0%       ~ (p=1.000 n=6) ¹
BuildMetricName/withSuffixes=false/Gauge_ratio_metric-2                        32.00 ± 0%   32.00 ± 0%       ~ (p=1.000 n=6) ¹
BuildMetricName/withSuffixes=false/Metric_with_per-unit_suffix_notation-2      24.00 ± 0%   24.00 ± 0%       ~ (p=1.000 n=6) ¹
BuildMetricName/withSuffixes=false/Metric_with_special_characters-2            48.00 ± 0%   48.00 ± 0%       ~ (p=1.000 n=6) ¹
BuildMetricName/withSuffixes=false/Metric_starting_with_digit-2                24.00 ± 0%   24.00 ± 0%       ~ (p=1.000 n=6) ¹
BuildMetricName/withSuffixes=false/Metric_with_multiple_underscores-2          64.00 ± 0%   64.00 ± 0%       ~ (p=1.000 n=6) ¹
BuildMetricName/withSuffixes=false/Metric_with_complex_unit-2                  32.00 ± 0%   32.00 ± 0%       ~ (p=1.000 n=6) ¹
geomean                                                                        53.22        53.22       +0.00%
¹ all samples are equal

                                                                             │  main.txt  │           no-regexp.txt            │
                                                                             │ allocs/op  │ allocs/op   vs base                │
BuildMetricName/withSuffixes=true/Basic_metric_with_no_special_characters-2    2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=6) ¹
BuildMetricName/withSuffixes=true/Counter_metric-2                             3.000 ± 0%   3.000 ± 0%       ~ (p=1.000 n=6) ¹
BuildMetricName/withSuffixes=true/Gauge_ratio_metric-2                         3.000 ± 0%   3.000 ± 0%       ~ (p=1.000 n=6) ¹
BuildMetricName/withSuffixes=true/Metric_with_per-unit_suffix_notation-2       4.000 ± 0%   4.000 ± 0%       ~ (p=1.000 n=6) ¹
BuildMetricName/withSuffixes=true/Metric_with_special_characters-2             2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=6) ¹
BuildMetricName/withSuffixes=true/Metric_starting_with_digit-2                 2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=6) ¹
BuildMetricName/withSuffixes=true/Metric_with_multiple_underscores-2           2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=6) ¹
BuildMetricName/withSuffixes=true/Metric_with_complex_unit-2                   5.000 ± 0%   5.000 ± 0%       ~ (p=1.000 n=6) ¹
BuildMetricName/withSuffixes=false/Basic_metric_with_no_special_characters-2   1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=6) ¹
BuildMetricName/withSuffixes=false/Counter_metric-2                            1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=6) ¹
BuildMetricName/withSuffixes=false/Gauge_ratio_metric-2                        1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=6) ¹
BuildMetricName/withSuffixes=false/Metric_with_per-unit_suffix_notation-2      1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=6) ¹
BuildMetricName/withSuffixes=false/Metric_with_special_characters-2            1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=6) ¹
BuildMetricName/withSuffixes=false/Metric_starting_with_digit-2                1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=6) ¹
BuildMetricName/withSuffixes=false/Metric_with_multiple_underscores-2          1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=6) ¹
BuildMetricName/withSuffixes=false/Metric_with_complex_unit-2                  1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=6) ¹
geomean                                                                        1.645        1.645       +0.00%
¹ all samples are equal
```