### PR TITLE
chore: bump golangci-lint to v2.0.2

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -26,14 +26,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install Go
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version: 1.24.x
       - name: Install snmp_exporter/generator dependencies
         run: sudo apt-get update && sudo apt-get -y install libsnmp-dev
         if: github.repository == 'prometheus/snmp_exporter'
       - name: Lint
-        uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
+        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
           args: --verbose
-          version: v1.64.7
+          version: v2.0.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,19 +1,26 @@
-run:
-  timeout: 15m
-
-output:
-  sort-results: true
-
+formatters:
+  enable:
+    - gci
+    - gofumpt
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/prometheus/otlptranslator)
+    gofumpt:
+      extra-rules: true
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
 linters:
   # Keep this list sorted alphabetically
   enable:
     - depguard
     - errorlint
     - exptostd
-    - gci
     - gocritic
     - godot
-    - gofumpt
     - loggercheck
     - misspell
     - nilnesserr
@@ -28,99 +35,72 @@ linters:
     - unused
     - usestdlibvars
     - whitespace
-
-issues:
-  max-issues-per-linter: 0
-  max-same-issues: 0
-  # The default exclusions are too aggressive. For one, they
-  # essentially disable any linting on doc comments. We disable
-  # default exclusions here and add exclusions fitting our codebase
-  # further down.
-  exclude-use-default: false
-  exclude-rules:
-    - linters:
-        - errcheck
-      # Taken from the default exclusions (that are otherwise disabled above).
-      text: Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
-    - path: _test.go
-      linters:
-        - errcheck
-    - linters:
-        - godot
-      source: "^// ==="
-    - linters:
-        - perfsprint
-      text: "fmt.Sprintf can be replaced with string concatenation"
-linters-settings:
-  depguard:
-    rules:
-      main:
-        deny:
-          - pkg: "sync/atomic"
-            desc: "Use go.uber.org/atomic instead of sync/atomic"
-          - pkg: "github.com/stretchr/testify/assert"
-            desc: "Use github.com/stretchr/testify/require instead of github.com/stretchr/testify/assert"
-          - pkg: "io/ioutil"
-            desc: "Use corresponding 'os' or 'io' functions instead."
-          - pkg: "regexp"
-            desc: "Use github.com/grafana/regexp instead of regexp"
-          - pkg: "github.com/pkg/errors"
-            desc: "Use 'errors' or 'fmt' instead of github.com/pkg/errors"
-          - pkg: "golang.org/x/exp/slices"
-            desc: "Use 'slices' instead."
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(github.com/prometheus/otlptranslator)
-  gofumpt:
-    extra-rules: true
-  perfsprint:
-     # Optimizes `fmt.Errorf`.
-    errorf: true
-  revive:
-    # By default, revive will enable only the linting rules that are named in the configuration file.
-    # So, it's needed to explicitly enable all required rules here.
-    rules:
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md
-      - name: blank-imports
-      - name: comment-spacings
-      - name: context-as-argument
-        arguments:
-          # Allow functions with test or bench signatures.
-          - allowTypesBefore: "*testing.T,testing.TB"
-      - name: context-keys-type
-      - name: dot-imports
-      - name: early-return
-        arguments:
-          - "preserveScope"
-      # A lot of false positives: incorrectly identifies channel draining as "empty code block".
-      # See https://github.com/mgechev/revive/issues/386
-      - name: empty-block
-        disabled: true
-      - name: error-naming
-      - name: error-return
-      - name: error-strings
-      - name: errorf
-      - name: exported
-      - name: increment-decrement
-      - name: indent-error-flow
-        arguments:
-          - "preserveScope"
-      - name: range
-      - name: receiver-naming
-      - name: redefines-builtin-id
-      - name: superfluous-else
-        arguments:
-          - "preserveScope"
-      - name: time-naming
-      - name: unexported-return
-      - name: unreachable-code
-      - name: unused-parameter
-      - name: var-declaration
-      - name: var-naming
-  testifylint:
-    disable:
-      - float-compare
-      - go-require
-    enable-all: true
+  settings:
+    depguard:
+      rules:
+        main:
+          deny:
+            - pkg: sync/atomic
+              desc: Use go.uber.org/atomic instead of sync/atomic
+            - pkg: github.com/stretchr/testify/assert
+              desc: Use github.com/stretchr/testify/require instead of github.com/stretchr/testify/assert
+            - pkg: io/ioutil
+              desc: Use corresponding 'os' or 'io' functions instead.
+            - pkg: regexp
+              desc: Use github.com/grafana/regexp instead of regexp
+            - pkg: github.com/pkg/errors
+              desc: Use 'errors' or 'fmt' instead of github.com/pkg/errors
+            - pkg: golang.org/x/exp/slices
+              desc: Use 'slices' instead.
+    perfsprint:
+      # Optimizes `fmt.Errorf`.
+      errorf: true
+    revive:
+      # By default, revive will enable only the linting rules that are named in the configuration file.
+      # So, it's needed to explicitly enable all required rules here.
+      rules:
+        # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md
+        - name: blank-imports
+        - name: comment-spacings
+        - name: context-as-argument
+          arguments:
+            # Allow functions with test or bench signatures.
+            - allowTypesBefore: '*testing.T,testing.TB'
+        - name: context-keys-type
+        - name: dot-imports
+        - name: early-return
+          arguments:
+            - preserveScope
+        # A lot of false positives: incorrectly identifies channel draining as "empty code block".
+        # See https://github.com/mgechev/revive/issues/386
+        - name: empty-block
+          disabled: true
+        - name: error-naming
+        - name: error-return
+        - name: error-strings
+        - name: errorf
+        - name: exported
+        - name: increment-decrement
+        - name: indent-error-flow
+          arguments:
+            - preserveScope
+        - name: range
+        - name: receiver-naming
+        - name: redefines-builtin-id
+        - name: superfluous-else
+          arguments:
+            - preserveScope
+        - name: time-naming
+        - name: unexported-return
+        - name: unreachable-code
+        - name: unused-parameter
+        - name: var-declaration
+        - name: var-naming
+    testifylint:
+      disable:
+        - float-compare
+        - go-require
+      enable-all: true
+run:
+  timeout: 15m
+version: "2"

--- a/metric_name_builder_test.go
+++ b/metric_name_builder_test.go
@@ -122,22 +122,22 @@ func TestNamespace(t *testing.T) {
 }
 
 func TestCleanUpUnit(t *testing.T) {
-	require.Equal(t, "", cleanUpUnit(""))
+	require.Empty(t, cleanUpUnit(""))
 	require.Equal(t, "a_b", cleanUpUnit("a b"))
 	require.Equal(t, "hello_world", cleanUpUnit("hello, world"))
 	require.Equal(t, "hello_you_2", cleanUpUnit("hello you 2"))
 	require.Equal(t, "1000", cleanUpUnit("$1000"))
-	require.Equal(t, "", cleanUpUnit("*+$^=)"))
+	require.Empty(t, cleanUpUnit("*+$^=)"))
 }
 
 func TestUnitMapGetOrDefault(t *testing.T) {
-	require.Equal(t, "", unitMapGetOrDefault(""))
+	require.Empty(t, unitMapGetOrDefault(""))
 	require.Equal(t, "seconds", unitMapGetOrDefault("s"))
 	require.Equal(t, "invalid", unitMapGetOrDefault("invalid"))
 }
 
 func TestPerUnitMapGetOrDefault(t *testing.T) {
-	require.Equal(t, "", perUnitMapGetOrDefault(""))
+	require.Empty(t, perUnitMapGetOrDefault(""))
 	require.Equal(t, "second", perUnitMapGetOrDefault("s"))
 	require.Equal(t, "invalid", perUnitMapGetOrDefault("invalid"))
 }


### PR DESCRIPTION
#### Description

Bump golangci-lint to v2.0.2 (aligned with prometheus actual version) and fixes newly raised issues