### PR TITLE
Add constants to auxilate migration of Collector's prometheusexporter

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -1,0 +1,46 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package otlptranslator
+
+const (
+	// MetricMetadataTypeKey is the key used to store the original Prometheus
+	// type in metric metadata:
+	// https://github.com/open-telemetry/opentelemetry-specification/blob/e6eccba97ebaffbbfad6d4358408a2cead0ec2df/specification/compatibility/prometheus_and_openmetrics.md#metric-metadata
+	MetricMetadataTypeKey = "prometheus.type"
+	// ExemplarTraceIDKey is the key used to store the trace ID in Prometheus
+	// exemplars:
+	// https://github.com/open-telemetry/opentelemetry-specification/blob/e6eccba97ebaffbbfad6d4358408a2cead0ec2df/specification/compatibility/prometheus_and_openmetrics.md#exemplars
+	ExemplarTraceIDKey = "trace_id"
+	// ExemplarSpanIDKey is the key used to store the Span ID in Prometheus
+	// exemplars:
+	// https://github.com/open-telemetry/opentelemetry-specification/blob/e6eccba97ebaffbbfad6d4358408a2cead0ec2df/specification/compatibility/prometheus_and_openmetrics.md#exemplars
+	ExemplarSpanIDKey = "span_id"
+	// ScopeInfoMetricName is the name of the metric used to preserve scope
+	// attributes in Prometheus format:
+	// https://github.com/open-telemetry/opentelemetry-specification/blob/e6eccba97ebaffbbfad6d4358408a2cead0ec2df/specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope
+	ScopeInfoMetricName = "otel_scope_info"
+	// ScopeNameLabelKey is the name of the label key used to identify the name
+	// of the OpenTelemetry scope which produced the metric:
+	// https://github.com/open-telemetry/opentelemetry-specification/blob/e6eccba97ebaffbbfad6d4358408a2cead0ec2df/specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope
+	ScopeNameLabelKey = "otel_scope_name"
+	// ScopeVersionLabelKey is the name of the label key used to identify the
+	// version of the OpenTelemetry scope which produced the metric:
+	// https://github.com/open-telemetry/opentelemetry-specification/blob/e6eccba97ebaffbbfad6d4358408a2cead0ec2df/specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope
+	ScopeVersionLabelKey = "otel_scope_version"
+	// TargetInfoMetricName is the name of the metric used to preserve resource
+	// attributes in Prometheus format:
+	// https://github.com/open-telemetry/opentelemetry-specification/blob/e6eccba97ebaffbbfad6d4358408a2cead0ec2df/specification/compatibility/prometheus_and_openmetrics.md#resource-attributes-1
+	// It originates from OpenMetrics:
+	// https://github.com/OpenObservability/OpenMetrics/blob/1386544931307dff279688f332890c31b6c5de36/specification/OpenMetrics.md#supporting-target-metadata-in-both-push-based-and-pull-based-systems
+	TargetInfoMetricName = "target_info"
+)


### PR DESCRIPTION
I'm opening this PR to start a quick discussion.

While working on migrating the translation package for the Collector's Prometheus exporter (without adding any new functionality to the exporter), I noticed that a few constants from the old library are used.

I've opened this PR just to showcase what constants we would need to add to our library to enable a transparent migration.

If we'd like to add them, that's a different story. If we don't want them, where would be the best place for those libraries to live?