### PR TITLE
Add vision

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
-# otlp-prometheus-translator
-Library providing API to convert OTLP metric and attribute names to respectively Prometheus metric and label names.
+# otlptranslator
+
+Library providing API to convert OTLP metric and attribute names to respectively Prometheus metric and label names. 
+
+# Problem statement
+
+Throughout the years, several different libraries that translate OTLP metrics into Prometheus metric formats (e.g. OpenMetrics) have been created and maintained by different parties.
+
+As new feature are being introduced to Prometheus, e.g. UTF-8 support, many of those old libraries start to lack behind and don't fulfill the expectations of users. To make things even worse, with different downstream projects adopting different translation libraries we're starting to see a fragmented ecosystem where data emitted from different projects start to look different.
+
+# Vision
+
+* Thrive to be the technical authority and go-to library for all projects that need to translate OpenTelemetry metric and attribute names to [Prometheus naming conventions](https://prometheus.io/docs/practices/naming/).
+* Focus on providing the most efficient library for said translation.


### PR DESCRIPTION
This PR writes down our vision for this library as the go-to library to translate OTLP metric and attribute names into Prometheus naming conventions, and nothing more than that.

This means we want to be the library used by:
* Prometheus (already done)
* OpenTelemetry-Collector's Prometheus exporter (accepted, but WIP)
* OpeneTelemetry-go-sdk's Prometheus exporter (in-discussion)
* [Thanos](https://github.com/thanos-io/thanos/tree/main/pkg/receive/otlptranslator) (no discussion so far)
* Cortex (done because uses Prometheus code)
* Mimir (done because uses Prometheus code)