### PR TITLE
Add vision (including Prometheus Remote Write)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
-# otlp-prometheus-translator
-Library providing API to convert OTLP metric and attribute names to respectively Prometheus metric and label names.
+# otlptranslator
+
+Library providing API to convert OTLP metric data to popular Prometheus metric formats:
+* OTLP metric and attribute names to Prometheus metric and label names, optionally following the [Prometheus naming conventions](https://prometheus.io/docs/practices/naming/).
+* OTLP metric to Prometheus Remote Write format.
+
+# Problem statement
+
+Throughout the years, several different libraries that translate OTLP metrics into Prometheus metric formats (e.g. OpenMetrics and Prometheus Remote Write) have been created, maintained and forked by different parties.
+
+As new features are being introduced to Prometheus, e.g. UTF-8 support, Native Histograms and Native Histogram Custom Buckets, many of those old libraries start to lack behind and don't fulfill the expectations of users. To make things even worse, with different downstream projects adopting different translation libraries we're starting to see a fragmented ecosystem where data emitted from different projects start to look different.
+
+# Vision
+
+* Thrive to be the technical authority and go-to library for all projects that need to translate OpenTelemetry metric and attribute names to [Prometheus naming conventions](https://prometheus.io/docs/practices/naming/).
+* Thrive to be the technical authority and go-to library for all projects that need to translate full OpenTelemetry metrics into the different versions of the Prometheus Remote-Write protocol.
+* Focus on providing the most efficient library for said translation.
+* Drive and evolve the [OpenTelemetry<->Prometheus compatibility specification](https://opentelemetry.io/docs/specs/otel/compatibility/prometheus_and_openmetrics/) with the experience we get from maintaining this library.


### PR DESCRIPTION
An alternative for #26 

---
This PR writes down our vision for this library as the go-to library to translate OTLP metric and attribute names into Prometheus naming conventions, and also translating OTLP format to PRW format.

This means we want to be the library used to translate names, by:
* Prometheus (already done)
* [OpenTelemetry-Collector's Prometheus exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/3ebd0ddc658b5ad88ff99da730191f21bcc2cb40/exporter/prometheusremotewriteexporter/exporter.go#L34) (accepted, but WIP)
* OpeneTelemetry-go-sdk's Prometheus exporter (in discussion)
* [Thanos](https://github.com/thanos-io/thanos/tree/main/pkg/receive/otlptranslator) (no discussion so far)
* Cortex (done because it uses Prometheus code)
* Mimir (done because it uses Prometheus code)


We want to be the library used to translate otlp->prw, by:
* [Prometheus](https://github.com/prometheus/prometheus/tree/main/storage/remote/otlptranslator/prometheusremotewrite) (in discussion)
* [OpenTelemetry-Collector's Prometheus Remote Write exporter ](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/3ebd0ddc658b5ad88ff99da730191f21bcc2cb40/exporter/prometheusremotewriteexporter/exporter.go#L35)(in discussion)
* [Thanos](https://github.com/thanos-io/thanos/blob/main/pkg/receive/otlptranslator/metrics_to_prw.go) (no discussions so far)
* Cortex (uses Prom code)
* Mimir (uses Prom code)