### PR TITLE
[chore] Refactor tests based on Go Test guidelines

### DIFF
--- a/metric_namer_test.go
+++ b/metric_namer_test.go
@@ -991,6 +991,60 @@ func TestMetricNamer_Build(t *testing.T) {
 			},
 			expected: "metric",
 		},
+
+		// Common OTel metrics to showcase how the namer works
+		{
+			name: "http.request.duration/Prometheus-style",
+			namer: MetricNamer{
+				UTF8Allowed:        false,
+				WithMetricSuffixes: true,
+			},
+			metric: Metric{
+				Name: "http.request.duration",
+				Unit: "ms",
+				Type: MetricTypeHistogram,
+			},
+			expected: "http_request_duration_milliseconds",
+		},
+		{
+			name: "http.request.duration/OTel-style",
+			namer: MetricNamer{
+				UTF8Allowed:        true,
+				WithMetricSuffixes: false,
+			},
+			metric: Metric{
+				Name: "http.request.duration",
+				Unit: "ms",
+				Type: MetricTypeHistogram,
+			},
+			expected: "http.request.duration",
+		},
+		{
+			name: "http.requests/Prometheus-style",
+			namer: MetricNamer{
+				UTF8Allowed:        false,
+				WithMetricSuffixes: true,
+			},
+			metric: Metric{
+				Name: "http.requests",
+				Unit: "1",
+				Type: MetricTypeMonotonicCounter,
+			},
+			expected: "http_requests_total",
+		},
+		{
+			name: "http.requests/OTel-style",
+			namer: MetricNamer{
+				UTF8Allowed:        true,
+				WithMetricSuffixes: false,
+			},
+			metric: Metric{
+				Name: "http.requests",
+				Unit: "1",
+				Type: MetricTypeMonotonicCounter,
+			},
+			expected: "http.requests",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #30 
That's a big one 😬 

---

It refactors our tests based on https://go.dev/wiki/TestComments; I tried to focus primarily on using Table-tests ~and removing usage of testify.Require~(See PR discussion)

While working on this, I noticed that we have many overlapping tests. We were testing the same things over and over again while testing `normalizeName` and `buildCompliantMetricName`(which just calls normalizeName). In this PR, I'm calling only `metricNamer.Build` and depending on the input we cover almost the whole codebase:

```
go test -timeout 30s -coverprofile=/var/folders/b4/65qyngfs6pdg3qdbhmjj3vt80000gn/T/vscode-gomTI7No/go-code-cover github.com/prometheus/otlptranslator

ok  	github.com/prometheus/otlptranslator	0.255s	coverage: 96.9% of statements
```