### PR TITLE
Refactor Label API

### DIFF
--- a/normalize_label.go
+++ b/normalize_label.go
@@ -24,15 +24,23 @@ import (
 	"unicode"
 )
 
-// NormalizeLabel normalizes the specified label to follow Prometheus label names standard.
+// LabelNamer is a helper struct to build label names.
+type LabelNamer struct {
+	UTF8Allowed bool
+}
+
+// Build normalizes the specified label to follow Prometheus label names standard.
 //
 // See rules at https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels.
 //
 // Labels that start with non-letter rune will be prefixed with "key_".
 // An exception is made for double-underscores which are allowed.
-func NormalizeLabel(label string) string {
+//
+// If UTF8Allowed is true, the label is returned as is. This option is provided just to
+// keep a consistent interface with the MetricNamer.
+func (ln *LabelNamer) Build(label string) string {
 	// Trivial case.
-	if len(label) == 0 {
+	if len(label) == 0 || ln.UTF8Allowed {
 		return label
 	}
 

--- a/normalize_label_bench_test.go
+++ b/normalize_label_bench_test.go
@@ -45,10 +45,11 @@ var labelBenchmarkInputs = []struct {
 }
 
 func BenchmarkNormalizeLabel(b *testing.B) {
+	labelNamer := LabelNamer{UTF8Allowed: false}
 	for _, input := range labelBenchmarkInputs {
 		b.Run(input.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				NormalizeLabel(input.label)
+				labelNamer.Build(input.label)
 			}
 		})
 	}

--- a/normalize_label_test.go
+++ b/normalize_label_test.go
@@ -40,9 +40,17 @@ func TestNormalizeLabel(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		t.Run(fmt.Sprintf("test_%d", i), func(t *testing.T) {
-			result := NormalizeLabel(test.label)
-			require.Equal(t, test.expected, result)
-		})
+		for _, utf8Allowed := range []bool{true, false} {
+			t.Run(fmt.Sprintf("test_%d", i), func(t *testing.T) {
+				labelNamer := LabelNamer{UTF8Allowed: utf8Allowed}
+				result := labelNamer.Build(test.label)
+
+				if utf8Allowed {
+					require.Equal(t, test.label, result)
+				} else {
+					require.Equal(t, test.expected, result)
+				}
+			})
+		}
 	}
 }


### PR DESCRIPTION
Fixes #31 

---

This PR refactors the API used to build label names. 

It follows a similar approach to our API for building metric names, with the caveat that it's much simpler and a no-op if UTF-8 is allowed.