### PR TITLE
GitHub: Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+<!--
+    Please give your PR a title in the form "area: short description". For example "LabelNamer: add Build method"
+
+    If your PR is to fix an issue, put "Fixes #issue-number" in the description.
+
+    Don't forget!
+
+    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.
+
+    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
+
+    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
+
+    - Performance improvements would need a benchmark test to prove it.
+
+    - All exposed objects should have a comment.
+
+    - All comments should start with a capital letter and end with a full stop.
+ -->


### PR DESCRIPTION
I propose we add a GitHub pull request template, in the same vein as [the Prometheus one](https://github.com/prometheus/prometheus/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1). In my opinion, it would be good to harmonize with the Prometheus repo itself on this aspect.