### PR TITLE
MetricNamer: escape namespaces when utf-8 not supported

### DIFF
--- a/metric_namer.go
+++ b/metric_namer.go
@@ -120,7 +120,10 @@ func (mn *MetricNamer) buildCompliantMetricName(name, unit string, metricType Me
 
 	// Namespace?
 	if mn.Namespace != "" {
-		return mn.Namespace + "_" + metricName
+		namespace := strings.Join(strings.FieldsFunc(mn.Namespace, func(r rune) bool {
+			return invalidMetricCharRE.MatchString(string(r))
+		}), "_")
+		return namespace + "_" + metricName
 	}
 
 	// Metric name starts with a digit? Prefix it with an underscore.

--- a/metric_namer_test.go
+++ b/metric_namer_test.go
@@ -128,7 +128,7 @@ func TestMetricNamer_Build(t *testing.T) {
 		{
 			name: "namespace with special characters",
 			namer: MetricNamer{
-				Namespace:          "test@namespace",
+				Namespace:          "test@namespace!!??",
 				UTF8Allowed:        false,
 				WithMetricSuffixes: false,
 			},
@@ -137,8 +137,7 @@ func TestMetricNamer_Build(t *testing.T) {
 				Unit: "",
 				Type: MetricTypeGauge,
 			},
-			wantMetricName: "test@namespace_metric", // TODO: should be "test_namespace_metric"
-
+			wantMetricName: "test_namespace_metric",
 		},
 
 		// UTF8Allowed = false, WithMetricSuffixes = true tests


### PR DESCRIPTION
Fixes https://github.com/prometheus/otlptranslator/issues/39

<!--
    Please give your PR a title in the form "area: short description". For example "LabelNamer: add Build method"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
