### PR TITLE
MetricNamer: return error if escaped name is empty or all `_`

### DIFF
--- a/label_namer_bench_test.go
+++ b/label_namer_bench_test.go
@@ -49,6 +49,7 @@ func BenchmarkNormalizeLabel(b *testing.B) {
 	for _, input := range labelBenchmarkInputs {
 		b.Run(input.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
+				//nolint:errcheck
 				labelNamer.Build(input.label)
 			}
 		})

--- a/metric_namer_bench_test.go
+++ b/metric_namer_bench_test.go
@@ -18,6 +18,7 @@ func BenchmarkBuild(b *testing.B) {
 					for _, scenario := range scenarios {
 						b.Run(scenario.name, func(b *testing.B) {
 							for i := 0; i < b.N; i++ {
+								//nolint:errcheck
 								builder.Build(scenario.metric)
 							}
 						})


### PR DESCRIPTION
Note, this changes the interface of the namers (they now can return error) which will require refactoring of callers.

Fixes https://github.com/prometheus/otlptranslator/issues/34