### PR TITLE
feat: Implement PermissiveLabelSanitization

### DIFF
--- a/label_namer.go
+++ b/label_namer.go
@@ -35,6 +35,7 @@ import (
 type LabelNamer struct {
 	UTF8Allowed bool
 	// PermissiveLabelSanitization, if true, disables prepending 'key' to labels starting with '_'.
+	// Deprecated: This will be removed in a future version of otlptranslator.
 	PermissiveLabelSanitization bool
 }
 

--- a/label_namer.go
+++ b/label_namer.go
@@ -34,6 +34,8 @@ import (
 //	result := namer.Build("http.method") // "http_method"
 type LabelNamer struct {
 	UTF8Allowed bool
+	// PermissiveLabelSanitization, if true, disables prepending 'key' to labels starting with '_'.
+	PermissiveLabelSanitization bool
 }
 
 // Build normalizes the specified label to follow Prometheus label names standard.
@@ -82,7 +84,7 @@ func (ln *LabelNamer) Build(label string) (normalizedName string, err error) {
 	// If label starts with a number, prepend with "key_".
 	if unicode.IsDigit(rune(normalizedName[0])) {
 		normalizedName = "key_" + normalizedName
-	} else if strings.HasPrefix(normalizedName, "_") && !strings.HasPrefix(normalizedName, "__") {
+	} else if !ln.PermissiveLabelSanitization && strings.HasPrefix(normalizedName, "_") && !strings.HasPrefix(normalizedName, "__") {
 		normalizedName = "key" + normalizedName
 	}
 

--- a/label_namer.go
+++ b/label_namer.go
@@ -35,7 +35,8 @@ import (
 //	result := namer.Build("http.method") // "http_method"
 type LabelNamer struct {
 	UTF8Allowed bool
-	// UnderscoreLabelSanitization, if true, enabled prepending 'key' to labels starting with '_'.
+	// UnderscoreLabelSanitization, if true, enabled prepending 'key' to labels
+	// starting with '_'. Reserved labels starting with `__` are not modified.
 	//
 	// Deprecated: This will be removed in a future version of otlptranslator.
 	UnderscoreLabelSanitization bool

--- a/label_namer.go
+++ b/label_namer.go
@@ -34,9 +34,9 @@ import (
 //	result := namer.Build("http.method") // "http_method"
 type LabelNamer struct {
 	UTF8Allowed bool
-	// PermissiveLabelSanitization, if true, disables prepending 'key' to labels starting with '_'.
+	// UnderscoreLabelSanitization, if true, enabled prepending 'key' to labels starting with '_'.
 	// Deprecated: This will be removed in a future version of otlptranslator.
-	PermissiveLabelSanitization bool
+	UnderscoreLabelSanitization bool
 }
 
 // Build normalizes the specified label to follow Prometheus label names standard.
@@ -85,7 +85,7 @@ func (ln *LabelNamer) Build(label string) (normalizedName string, err error) {
 	// If label starts with a number, prepend with "key_".
 	if unicode.IsDigit(rune(normalizedName[0])) {
 		normalizedName = "key_" + normalizedName
-	} else if !ln.PermissiveLabelSanitization && strings.HasPrefix(normalizedName, "_") && !strings.HasPrefix(normalizedName, "__") {
+	} else if ln.UnderscoreLabelSanitization && strings.HasPrefix(normalizedName, "_") && !strings.HasPrefix(normalizedName, "__") {
 		normalizedName = "key" + normalizedName
 	}
 

--- a/label_namer_test.go
+++ b/label_namer_test.go
@@ -21,71 +21,71 @@ import (
 )
 
 var labelTestCases = []struct {
-	label               string
-	sanitized           string
-	sanitizedPermissive string
-	wantEscapeErr       bool
-	wantUTF8err         bool
+	label                string
+	sanitized            string
+	sanitizedUnderscores string
+	wantEscapeErr        bool
+	wantUTF8err          bool
 }{
 	{
-		label:               "",
-		sanitized:           "",
-		sanitizedPermissive: "",
-		wantEscapeErr:       true,
-		wantUTF8err:         true,
+		label:                "",
+		sanitized:            "",
+		sanitizedUnderscores: "",
+		wantEscapeErr:        true,
+		wantUTF8err:          true,
 	},
 	{
-		label:               "__",
-		sanitized:           "__",
-		sanitizedPermissive: "__",
-		wantEscapeErr:       false,
-		wantUTF8err:         false,
+		label:                "__",
+		sanitized:            "__",
+		sanitizedUnderscores: "__",
+		wantEscapeErr:        false,
+		wantUTF8err:          false,
 	},
 	{
-		label:               "label:with:colons",
-		sanitized:           "label_with_colons",
-		sanitizedPermissive: "label_with_colons",
+		label:                "label:with:colons",
+		sanitized:            "label_with_colons",
+		sanitizedUnderscores: "label_with_colons",
 	},
 	{
-		label:               "LabelWithCapitalLetters",
-		sanitized:           "LabelWithCapitalLetters",
-		sanitizedPermissive: "LabelWithCapitalLetters",
+		label:                "LabelWithCapitalLetters",
+		sanitized:            "LabelWithCapitalLetters",
+		sanitizedUnderscores: "LabelWithCapitalLetters",
 	},
 	{
-		label:               "label!with&special$chars)",
-		sanitized:           "label_with_special_chars_",
-		sanitizedPermissive: "label_with_special_chars_",
+		label:                "label!with&special$chars)",
+		sanitized:            "label_with_special_chars_",
+		sanitizedUnderscores: "label_with_special_chars_",
 	},
 	{
-		label:               "label_with_foreign_characters_字符",
-		sanitized:           "label_with_foreign_characters___",
-		sanitizedPermissive: "label_with_foreign_characters___",
+		label:                "label_with_foreign_characters_字符",
+		sanitized:            "label_with_foreign_characters___",
+		sanitizedUnderscores: "label_with_foreign_characters___",
 	},
 	{
-		label:               "label.with.dots",
-		sanitized:           "label_with_dots",
-		sanitizedPermissive: "label_with_dots",
+		label:                "label.with.dots",
+		sanitized:            "label_with_dots",
+		sanitizedUnderscores: "label_with_dots",
 	},
 	{
-		label:               "123label",
-		sanitized:           "key_123label",
-		sanitizedPermissive: "key_123label",
+		label:                "123label",
+		sanitized:            "key_123label",
+		sanitizedUnderscores: "key_123label",
 	},
 	{
-		label:               "_label_starting_with_underscore",
-		sanitized:           "key_label_starting_with_underscore",
-		sanitizedPermissive: "_label_starting_with_underscore",
+		label:                "_label_starting_with_underscore",
+		sanitized:            "_label_starting_with_underscore",
+		sanitizedUnderscores: "key_label_starting_with_underscore",
 	},
 	{
-		label:               "__label_starting_with_2underscores",
-		sanitized:           "__label_starting_with_2underscores",
-		sanitizedPermissive: "__label_starting_with_2underscores",
+		label:                "__label_starting_with_2underscores",
+		sanitized:            "__label_starting_with_2underscores",
+		sanitizedUnderscores: "__label_starting_with_2underscores",
 	},
 	{
-		label:               "ようこそ",
-		sanitized:           "",
-		sanitizedPermissive: "",
-		wantEscapeErr:       true,
+		label:                "ようこそ",
+		sanitized:            "",
+		sanitizedUnderscores: "",
+		wantEscapeErr:        true,
 	},
 }
 
@@ -107,12 +107,12 @@ func TestNormalizeLabel(t *testing.T) {
 			if tt.wantEscapeErr {
 				return
 			}
-			labelNamer.PermissiveLabelSanitization = true
+			labelNamer.UnderscoreLabelSanitization = true
 			got, err = labelNamer.Build(tt.label)
 			if err != nil {
 				t.Errorf("LabelNamer.Build(%q) (permissive) returned error %v, want nil", tt.label, err)
 			}
-			if got != tt.sanitizedPermissive {
+			if got != tt.sanitizedUnderscores {
 				t.Errorf("LabelNamer.Build(%q) (permissive) = %q, want %q", tt.label, got, tt.sanitized)
 			}
 		})
@@ -137,7 +137,7 @@ func TestNormalizeLabelUTF8Allowed(t *testing.T) {
 			if tt.wantEscapeErr {
 				return
 			}
-			labelNamer.PermissiveLabelSanitization = true
+			labelNamer.UnderscoreLabelSanitization = true
 			got, err = labelNamer.Build(tt.label)
 			if err != nil {
 				t.Errorf("LabelNamer.Build(%q) (permissive) returned error %v, want nil", tt.label, err)

--- a/label_namer_test.go
+++ b/label_namer_test.go
@@ -21,22 +21,72 @@ import (
 )
 
 var labelTestCases = []struct {
-	label         string
-	sanitized     string
-	wantEscapeErr bool
-	wantUTF8err   bool
+	label               string
+	sanitized           string
+	sanitizedPermissive string
+	wantEscapeErr       bool
+	wantUTF8err         bool
 }{
-	{label: "", sanitized: "", wantEscapeErr: true, wantUTF8err: true},
-	{label: "__", sanitized: "__", wantEscapeErr: false, wantUTF8err: false},
-	{label: "label:with:colons", sanitized: "label_with_colons"},
-	{label: "LabelWithCapitalLetters", sanitized: "LabelWithCapitalLetters"},
-	{label: "label!with&special$chars)", sanitized: "label_with_special_chars_"},
-	{label: "label_with_foreign_characters_字符", sanitized: "label_with_foreign_characters___"},
-	{label: "label.with.dots", sanitized: "label_with_dots"},
-	{label: "123label", sanitized: "key_123label"},
-	{label: "_label_starting_with_underscore", sanitized: "key_label_starting_with_underscore"},
-	{label: "__label_starting_with_2underscores", sanitized: "__label_starting_with_2underscores"},
-	{label: "ようこそ", sanitized: "", wantEscapeErr: true},
+	{
+		label:               "",
+		sanitized:           "",
+		sanitizedPermissive: "",
+		wantEscapeErr:       true,
+		wantUTF8err:         true,
+	},
+	{
+		label:               "__",
+		sanitized:           "__",
+		sanitizedPermissive: "__",
+		wantEscapeErr:       false,
+		wantUTF8err:         false,
+	},
+	{
+		label:               "label:with:colons",
+		sanitized:           "label_with_colons",
+		sanitizedPermissive: "label_with_colons",
+	},
+	{
+		label:               "LabelWithCapitalLetters",
+		sanitized:           "LabelWithCapitalLetters",
+		sanitizedPermissive: "LabelWithCapitalLetters",
+	},
+	{
+		label:               "label!with&special$chars)",
+		sanitized:           "label_with_special_chars_",
+		sanitizedPermissive: "label_with_special_chars_",
+	},
+	{
+		label:               "label_with_foreign_characters_字符",
+		sanitized:           "label_with_foreign_characters___",
+		sanitizedPermissive: "label_with_foreign_characters___",
+	},
+	{
+		label:               "label.with.dots",
+		sanitized:           "label_with_dots",
+		sanitizedPermissive: "label_with_dots",
+	},
+	{
+		label:               "123label",
+		sanitized:           "key_123label",
+		sanitizedPermissive: "key_123label",
+	},
+	{
+		label:               "_label_starting_with_underscore",
+		sanitized:           "key_label_starting_with_underscore",
+		sanitizedPermissive: "_label_starting_with_underscore",
+	},
+	{
+		label:               "__label_starting_with_2underscores",
+		sanitized:           "__label_starting_with_2underscores",
+		sanitizedPermissive: "__label_starting_with_2underscores",
+	},
+	{
+		label:               "ようこそ",
+		sanitized:           "",
+		sanitizedPermissive: "",
+		wantEscapeErr:       true,
+	},
 }
 
 func TestNormalizeLabel(t *testing.T) {
@@ -53,6 +103,17 @@ func TestNormalizeLabel(t *testing.T) {
 			}
 			if got != tt.sanitized {
 				t.Errorf("LabelNamer.Build(%q) = %q, want %q", tt.label, got, tt.sanitized)
+			}
+			if tt.wantEscapeErr {
+				return
+			}
+			labelNamer.PermissiveLabelSanitization = true
+			got, err = labelNamer.Build(tt.label)
+			if err != nil {
+				t.Errorf("LabelNamer.Build(%q) (permissive) returned error %v, want nil", tt.label, err)
+			}
+			if got != tt.sanitizedPermissive {
+				t.Errorf("LabelNamer.Build(%q) (permissive) = %q, want %q", tt.label, got, tt.sanitized)
 			}
 		})
 	}
@@ -72,6 +133,17 @@ func TestNormalizeLabelUTF8Allowed(t *testing.T) {
 			}
 			if got != tt.label {
 				t.Errorf("LabelNamer.Build(%q) = %q, want %q", tt.label, got, tt.label)
+			}
+			if tt.wantEscapeErr {
+				return
+			}
+			labelNamer.PermissiveLabelSanitization = true
+			got, err = labelNamer.Build(tt.label)
+			if err != nil {
+				t.Errorf("LabelNamer.Build(%q) (permissive) returned error %v, want nil", tt.label, err)
+			}
+			if got != tt.label {
+				t.Errorf("LabelNamer.Build(%q) (permissive) = %q, want %q", tt.label, got, tt.sanitized)
 			}
 		})
 	}

--- a/label_namer_test.go
+++ b/label_namer_test.go
@@ -32,6 +32,7 @@ var labelTestCases = []struct {
 	{label: "123label", sanitized: "key_123label"},
 	{label: "_label_starting_with_underscore", sanitized: "_label_starting_with_underscore"},
 	{label: "__label_starting_with_2underscores", sanitized: "__label_starting_with_2underscores"},
+	{label: "ようこそ", sanitized: ""},
 }
 
 func TestBuildLabel(t *testing.T) {

--- a/label_namer_test.go
+++ b/label_namer_test.go
@@ -60,6 +60,8 @@ func TestBuildLabel_UTF8Allowed(t *testing.T) {
 
 // TestBuildLabel_Underscores confirms that `key_` is only prepended to label
 // names starting with an underscore if UnderscoreLabelSanitization is true.
+// Labels starting with a number always get `key_` prepended so they are valid
+// Prometheus labels.
 func TestBuildLabel_Underscores(t *testing.T) {
 	labelTestCases := []struct {
 		label                string

--- a/label_namer_test.go
+++ b/label_namer_test.go
@@ -21,50 +21,17 @@ import (
 )
 
 var labelTestCases = []struct {
-	label                string
-	sanitized            string
-	sanitizedUnderscores string
+	label     string
+	sanitized string
 }{
-	{
-		label:                "label:with:colons",
-		sanitized:            "label_with_colons",
-		sanitizedUnderscores: "label_with_colons",
-	},
-	{
-		label:                "LabelWithCapitalLetters",
-		sanitized:            "LabelWithCapitalLetters",
-		sanitizedUnderscores: "LabelWithCapitalLetters",
-	},
-	{
-		label:                "label!with&special$chars)",
-		sanitized:            "label_with_special_chars_",
-		sanitizedUnderscores: "label_with_special_chars_",
-	},
-	{
-		label:                "label_with_foreign_characters_字符",
-		sanitized:            "label_with_foreign_characters___",
-		sanitizedUnderscores: "label_with_foreign_characters___",
-	},
-	{
-		label:                "label.with.dots",
-		sanitized:            "label_with_dots",
-		sanitizedUnderscores: "label_with_dots",
-	},
-	{
-		label:                "123label",
-		sanitized:            "key_123label",
-		sanitizedUnderscores: "key_123label",
-	},
-	{
-		label:                "_label_starting_with_underscore",
-		sanitized:            "_label_starting_with_underscore",
-		sanitizedUnderscores: "key_label_starting_with_underscore",
-	},
-	{
-		label:                "__label_starting_with_2underscores",
-		sanitized:            "__label_starting_with_2underscores",
-		sanitizedUnderscores: "__label_starting_with_2underscores",
-	},
+	{label: "label:with:colons", sanitized: "label_with_colons"},
+	{label: "LabelWithCapitalLetters", sanitized: "LabelWithCapitalLetters"},
+	{label: "label!with&special$chars)", sanitized: "label_with_special_chars_"},
+	{label: "label_with_foreign_characters_字符", sanitized: "label_with_foreign_characters___"},
+	{label: "label.with.dots", sanitized: "label_with_dots"},
+	{label: "123label", sanitized: "key_123label"},
+	{label: "_label_starting_with_underscore", sanitized: "_label_starting_with_underscore"},
+	{label: "__label_starting_with_2underscores", sanitized: "__label_starting_with_2underscores"},
 }
 
 func TestBuildLabel(t *testing.T) {


### PR DESCRIPTION
Needed by Otel collector to optionally not prepend underscored label names with "key_".

This is a breaking change because by default we do not want to prepend `key_`.
