### PR TITLE
Remove usage of regexp

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -46,8 +46,6 @@ linters:
               desc: Use github.com/stretchr/testify/require instead of github.com/stretchr/testify/assert
             - pkg: io/ioutil
               desc: Use corresponding 'os' or 'io' functions instead.
-            - pkg: regexp
-              desc: Use github.com/grafana/regexp instead of regexp
             - pkg: github.com/pkg/errors
               desc: Use 'errors' or 'fmt' instead of github.com/pkg/errors
             - pkg: golang.org/x/exp/slices

--- a/go.mod
+++ b/go.mod
@@ -3,5 +3,3 @@ module github.com/prometheus/otlptranslator
 go 1.23.0
 
 toolchain go1.24.1
-
-require github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc h1:GN2Lv3MGO7AS6PrRoT6yV5+wkrOpcszoIsO4+4ds248=
-github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc/go.mod h1:+JKpmjMGhpgPL+rXZ5nsZieVzvarn86asRlBg4uNGnk=

--- a/metric_namer.go
+++ b/metric_namer.go
@@ -24,8 +24,6 @@ import (
 	"slices"
 	"strings"
 	"unicode"
-
-	"github.com/grafana/regexp"
 )
 
 // The map to translate OTLP units to Prometheus units
@@ -206,8 +204,6 @@ func (mn *MetricNamer) buildCompliantMetricName(name, unit string, metricType Me
 	normalizedName = metricName
 	return
 }
-
-var multipleUnderscoresRE = regexp.MustCompile(`__+`)
 
 // isValidCompliantMetricChar checks if a rune is a valid metric name character (a-z, A-Z, 0-9, :).
 func isValidCompliantMetricChar(r rune) bool {

--- a/strconv.go
+++ b/strconv.go
@@ -87,3 +87,30 @@ func isReservedLabel(name string) (bool, string) {
 	}
 	return true, name[2 : len(name)-2]
 }
+
+// collapseMultipleUnderscores replaces multiple consecutive underscores with a single underscore.
+// This is equivalent to regexp.MustCompile(`__+`).ReplaceAllString(s, "_") but without using regex.
+func collapseMultipleUnderscores(s string) string {
+	if len(s) == 0 {
+		return s
+	}
+
+	var b strings.Builder
+	b.Grow(len(s))
+	prevWasUnderscore := false
+
+	for _, r := range s {
+		if r == '_' {
+			if !prevWasUnderscore {
+				b.WriteRune('_')
+				prevWasUnderscore = true
+			}
+			// Skip consecutive underscores
+		} else {
+			b.WriteRune(r)
+			prevWasUnderscore = false
+		}
+	}
+
+	return b.String()
+}

--- a/unit_namer.go
+++ b/unit_namer.go
@@ -123,8 +123,7 @@ func buildUnitSuffixes(unit string) (mainUnitSuffix, perUnitSuffix string) {
 func cleanUpUnit(unit string) string {
 	// Multiple consecutive underscores are replaced with a single underscore.
 	// This is part of the OTel to Prometheus specification: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.38.0/specification/compatibility/prometheus_and_openmetrics.md#otlp-metric-points-to-prometheus.
-	return strings.TrimPrefix(multipleUnderscoresRE.ReplaceAllString(
+	return strings.TrimPrefix(collapseMultipleUnderscores(
 		strings.Map(replaceInvalidMetricChar, unit),
-		"_",
 	), "_")
 }


### PR DESCRIPTION
Fixes #46 

---

This PR removes usage of grafana/regexp, and slightly improves performance while doing so.

```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/otlptranslator
cpu: Apple M2 Pro
                                                                                     │    main.txt    │              new.txt               │
                                                                                     │    sec/op    │   sec/op     vs base               │
Build/withSuffixes=true/utf8Allowed=true/Basic_metric_with_no_special_characters-2     43.52n ±  1%   43.84n ± 1%   +0.72% (p=0.002 n=6)
Build/withSuffixes=true/utf8Allowed=true/Counter_metric-2                              66.97n ±  1%   68.11n ± 1%   +1.72% (p=0.004 n=6)
Build/withSuffixes=true/utf8Allowed=true/Gauge_ratio_metric-2                          85.34n ±  7%   84.67n ± 0%   -0.78% (p=0.002 n=6)
Build/withSuffixes=true/utf8Allowed=true/Metric_with_per-unit_suffix_notation-2        128.0n ± 10%   123.0n ± 1%   -3.95% (p=0.004 n=6)
Build/withSuffixes=true/utf8Allowed=true/Metric_with_special_characters-2              47.09n ±  7%   45.94n ± 1%   -2.43% (p=0.017 n=6)
Build/withSuffixes=true/utf8Allowed=true/Metric_starting_with_digit-2                  44.36n ±  1%   44.04n ± 1%        ~ (p=0.065 n=6)
Build/withSuffixes=true/utf8Allowed=true/Metric_with_multiple_underscores-2            46.73n ±  2%   46.85n ± 1%        ~ (p=0.457 n=6)
Build/withSuffixes=true/utf8Allowed=true/Metric_with_complex_unit-2                    160.8n ±  0%   162.0n ± 1%   +0.75% (p=0.004 n=6)
Build/withSuffixes=true/utf8Allowed=false/Basic_metric_with_no_special_characters-2    192.6n ±  4%   149.2n ± 1%  -22.53% (p=0.002 n=6)
Build/withSuffixes=true/utf8Allowed=false/Counter_metric-2                             235.8n ±  4%   186.9n ± 3%  -20.74% (p=0.002 n=6)
Build/withSuffixes=true/utf8Allowed=false/Gauge_ratio_metric-2                         218.4n ±  1%   167.2n ± 1%  -23.42% (p=0.002 n=6)
Build/withSuffixes=true/utf8Allowed=false/Metric_with_per-unit_suffix_notation-2       327.0n ±  1%   268.5n ± 3%  -17.89% (p=0.002 n=6)
Build/withSuffixes=true/utf8Allowed=false/Metric_with_special_characters-2             250.6n ±  2%   208.8n ± 2%  -16.72% (p=0.002 n=6)
Build/withSuffixes=true/utf8Allowed=false/Metric_starting_with_digit-2                 169.1n ±  3%   121.6n ± 1%  -28.09% (p=0.002 n=6)
Build/withSuffixes=true/utf8Allowed=false/Metric_with_multiple_underscores-2           291.3n ±  3%   238.5n ± 0%  -18.14% (p=0.002 n=6)
Build/withSuffixes=true/utf8Allowed=false/Metric_with_complex_unit-2                   466.9n ±  6%   381.4n ± 1%  -18.31% (p=0.002 n=6)
Build/withSuffixes=false/utf8Allowed=true/Basic_metric_with_no_special_characters-2    27.95n ±  0%   26.08n ± 1%   -6.69% (p=0.002 n=6)
Build/withSuffixes=false/utf8Allowed=true/Counter_metric-2                             27.95n ±  1%   26.18n ± 1%   -6.30% (p=0.002 n=6)
Build/withSuffixes=false/utf8Allowed=true/Gauge_ratio_metric-2                         27.99n ±  2%   25.70n ± 1%   -8.20% (p=0.002 n=6)
Build/withSuffixes=false/utf8Allowed=true/Metric_with_per-unit_suffix_notation-2       26.78n ±  1%   25.44n ± 2%   -5.02% (p=0.002 n=6)
Build/withSuffixes=false/utf8Allowed=true/Metric_with_special_characters-2             29.14n ±  1%   27.32n ± 2%   -6.24% (p=0.002 n=6)
Build/withSuffixes=false/utf8Allowed=true/Metric_starting_with_digit-2                 26.66n ±  2%   25.16n ± 4%   -5.66% (p=0.002 n=6)
Build/withSuffixes=false/utf8Allowed=true/Metric_with_multiple_underscores-2           28.64n ±  7%   27.50n ± 4%   -3.98% (p=0.015 n=6)
Build/withSuffixes=false/utf8Allowed=true/Metric_with_complex_unit-2                   26.13n ±  2%   25.21n ± 1%   -3.50% (p=0.002 n=6)
Build/withSuffixes=false/utf8Allowed=false/Basic_metric_with_no_special_characters-2   136.4n ±  1%   131.8n ± 1%   -3.34% (p=0.002 n=6)
Build/withSuffixes=false/utf8Allowed=false/Counter_metric-2                            142.2n ±  3%   134.0n ± 1%   -5.80% (p=0.002 n=6)
Build/withSuffixes=false/utf8Allowed=false/Gauge_ratio_metric-2                        138.6n ±  1%   129.3n ± 1%   -6.64% (p=0.002 n=6)
Build/withSuffixes=false/utf8Allowed=false/Metric_with_per-unit_suffix_notation-2      128.2n ±  1%   119.1n ± 1%   -7.02% (p=0.002 n=6)
Build/withSuffixes=false/utf8Allowed=false/Metric_with_special_characters-2            230.3n ±  3%   212.3n ± 0%   -7.82% (p=0.002 n=6)
Build/withSuffixes=false/utf8Allowed=false/Metric_starting_with_digit-2                131.7n ±  1%   123.5n ± 0%   -6.19% (p=0.002 n=6)
Build/withSuffixes=false/utf8Allowed=false/Metric_with_multiple_underscores-2          205.9n ±  1%   192.2n ± 0%   -6.65% (p=0.002 n=6)
Build/withSuffixes=false/utf8Allowed=false/Metric_with_complex_unit-2                  139.2n ±  1%   129.4n ± 1%   -7.04% (p=0.002 n=6)
geomean                                                                                92.91n         84.85n        -8.68%

                                                                                     │   main.txt    │               new.txt               │
                                                                                     │    B/op     │    B/op     vs base                 │
Build/withSuffixes=true/utf8Allowed=true/Basic_metric_with_no_special_characters-2      48.00 ± 0%   48.00 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=true/utf8Allowed=true/Counter_metric-2                               96.00 ± 0%   96.00 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=true/utf8Allowed=true/Gauge_ratio_metric-2                           112.0 ± 0%   112.0 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=true/utf8Allowed=true/Metric_with_per-unit_suffix_notation-2         120.0 ± 0%   120.0 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=true/utf8Allowed=true/Metric_with_special_characters-2               64.00 ± 0%   64.00 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=true/utf8Allowed=true/Metric_starting_with_digit-2                   40.00 ± 0%   40.00 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=true/utf8Allowed=true/Metric_with_multiple_underscores-2             80.00 ± 0%   80.00 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=true/utf8Allowed=true/Metric_with_complex_unit-2                     176.0 ± 0%   176.0 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=true/utf8Allowed=false/Basic_metric_with_no_special_characters-2     160.0 ± 0%   128.0 ± 0%  -20.00% (p=0.002 n=6)
Build/withSuffixes=true/utf8Allowed=false/Counter_metric-2                              256.0 ± 0%   224.0 ± 0%  -12.50% (p=0.002 n=6)
Build/withSuffixes=true/utf8Allowed=false/Gauge_ratio_metric-2                          176.0 ± 0%   144.0 ± 0%  -18.18% (p=0.002 n=6)
Build/withSuffixes=true/utf8Allowed=false/Metric_with_per-unit_suffix_notation-2        256.0 ± 0%   208.0 ± 0%  -18.75% (p=0.002 n=6)
Build/withSuffixes=true/utf8Allowed=false/Metric_with_special_characters-2              240.0 ± 0%   208.0 ± 0%  -13.33% (p=0.002 n=6)
Build/withSuffixes=true/utf8Allowed=false/Metric_starting_with_digit-2                 120.00 ± 0%   88.00 ± 0%  -26.67% (p=0.002 n=6)
Build/withSuffixes=true/utf8Allowed=false/Metric_with_multiple_underscores-2            240.0 ± 0%   208.0 ± 0%  -13.33% (p=0.002 n=6)
Build/withSuffixes=true/utf8Allowed=false/Metric_with_complex_unit-2                    368.0 ± 0%   304.0 ± 0%  -17.39% (p=0.002 n=6)
Build/withSuffixes=false/utf8Allowed=true/Basic_metric_with_no_special_characters-2     32.00 ± 0%   32.00 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=false/utf8Allowed=true/Counter_metric-2                              32.00 ± 0%   32.00 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=false/utf8Allowed=true/Gauge_ratio_metric-2                          32.00 ± 0%   32.00 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=false/utf8Allowed=true/Metric_with_per-unit_suffix_notation-2        24.00 ± 0%   24.00 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=false/utf8Allowed=true/Metric_with_special_characters-2              48.00 ± 0%   48.00 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=false/utf8Allowed=true/Metric_starting_with_digit-2                  24.00 ± 0%   24.00 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=false/utf8Allowed=true/Metric_with_multiple_underscores-2            64.00 ± 0%   64.00 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=false/utf8Allowed=true/Metric_with_complex_unit-2                    32.00 ± 0%   32.00 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=false/utf8Allowed=false/Basic_metric_with_no_special_characters-2    64.00 ± 0%   64.00 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=false/utf8Allowed=false/Counter_metric-2                             64.00 ± 0%   64.00 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=false/utf8Allowed=false/Gauge_ratio_metric-2                         64.00 ± 0%   64.00 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=false/utf8Allowed=false/Metric_with_per-unit_suffix_notation-2       56.00 ± 0%   56.00 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=false/utf8Allowed=false/Metric_with_special_characters-2             160.0 ± 0%   160.0 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=false/utf8Allowed=false/Metric_starting_with_digit-2                 56.00 ± 0%   56.00 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=false/utf8Allowed=false/Metric_with_multiple_underscores-2           96.00 ± 0%   96.00 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=false/utf8Allowed=false/Metric_with_complex_unit-2                   64.00 ± 0%   64.00 ± 0%        ~ (p=1.000 n=6) ¹
geomean                                                                                 81.73        77.86        -4.74%
¹ all samples are equal

                                                                                     │   main.txt    │               new.txt               │
                                                                                     │  allocs/op  │ allocs/op   vs base                 │
Build/withSuffixes=true/utf8Allowed=true/Basic_metric_with_no_special_characters-2      2.000 ± 0%   2.000 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=true/utf8Allowed=true/Counter_metric-2                               3.000 ± 0%   3.000 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=true/utf8Allowed=true/Gauge_ratio_metric-2                           3.000 ± 0%   3.000 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=true/utf8Allowed=true/Metric_with_per-unit_suffix_notation-2         4.000 ± 0%   4.000 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=true/utf8Allowed=true/Metric_with_special_characters-2               2.000 ± 0%   2.000 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=true/utf8Allowed=true/Metric_starting_with_digit-2                   2.000 ± 0%   2.000 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=true/utf8Allowed=true/Metric_with_multiple_underscores-2             2.000 ± 0%   2.000 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=true/utf8Allowed=true/Metric_with_complex_unit-2                     5.000 ± 0%   5.000 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=true/utf8Allowed=false/Basic_metric_with_no_special_characters-2     6.000 ± 0%   4.000 ± 0%  -33.33% (p=0.002 n=6)
Build/withSuffixes=true/utf8Allowed=false/Counter_metric-2                              7.000 ± 0%   5.000 ± 0%  -28.57% (p=0.002 n=6)
Build/withSuffixes=true/utf8Allowed=false/Gauge_ratio_metric-2                          6.000 ± 0%   4.000 ± 0%  -33.33% (p=0.002 n=6)
Build/withSuffixes=true/utf8Allowed=false/Metric_with_per-unit_suffix_notation-2       10.000 ± 0%   7.000 ± 0%  -30.00% (p=0.002 n=6)
Build/withSuffixes=true/utf8Allowed=false/Metric_with_special_characters-2              6.000 ± 0%   4.000 ± 0%  -33.33% (p=0.002 n=6)
Build/withSuffixes=true/utf8Allowed=false/Metric_starting_with_digit-2                  6.000 ± 0%   4.000 ± 0%  -33.33% (p=0.002 n=6)
Build/withSuffixes=true/utf8Allowed=false/Metric_with_multiple_underscores-2            6.000 ± 0%   4.000 ± 0%  -33.33% (p=0.002 n=6)
Build/withSuffixes=true/utf8Allowed=false/Metric_with_complex_unit-2                   12.000 ± 0%   8.000 ± 0%  -33.33% (p=0.002 n=6)
Build/withSuffixes=false/utf8Allowed=true/Basic_metric_with_no_special_characters-2     1.000 ± 0%   1.000 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=false/utf8Allowed=true/Counter_metric-2                              1.000 ± 0%   1.000 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=false/utf8Allowed=true/Gauge_ratio_metric-2                          1.000 ± 0%   1.000 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=false/utf8Allowed=true/Metric_with_per-unit_suffix_notation-2        1.000 ± 0%   1.000 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=false/utf8Allowed=true/Metric_with_special_characters-2              1.000 ± 0%   1.000 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=false/utf8Allowed=true/Metric_starting_with_digit-2                  1.000 ± 0%   1.000 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=false/utf8Allowed=true/Metric_with_multiple_underscores-2            1.000 ± 0%   1.000 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=false/utf8Allowed=true/Metric_with_complex_unit-2                    1.000 ± 0%   1.000 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=false/utf8Allowed=false/Basic_metric_with_no_special_characters-2    3.000 ± 0%   3.000 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=false/utf8Allowed=false/Counter_metric-2                             3.000 ± 0%   3.000 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=false/utf8Allowed=false/Gauge_ratio_metric-2                         3.000 ± 0%   3.000 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=false/utf8Allowed=false/Metric_with_per-unit_suffix_notation-2       3.000 ± 0%   3.000 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=false/utf8Allowed=false/Metric_with_special_characters-2             4.000 ± 0%   4.000 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=false/utf8Allowed=false/Metric_starting_with_digit-2                 3.000 ± 0%   3.000 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=false/utf8Allowed=false/Metric_with_multiple_underscores-2           3.000 ± 0%   3.000 ± 0%        ~ (p=1.000 n=6) ¹
Build/withSuffixes=false/utf8Allowed=false/Metric_with_complex_unit-2                   3.000 ± 0%   3.000 ± 0%        ~ (p=1.000 n=6) ¹
geomean                                                                                 2.781        2.523        -9.31%
¹ all samples are equal

```