### PR TITLE
feat(label_namer): skip allocation for already-compliant labels

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/prometheus/otlptranslator
 
-go 1.23.0
+go 1.24.0
 
 toolchain go1.24.1

--- a/label_namer.go
+++ b/label_namer.go
@@ -74,6 +74,10 @@ func (ln *LabelNamer) Build(label string) (string, error) {
 		return label, nil
 	}
 
+	if canFastPathLabel(label, ln.PreserveMultipleUnderscores, ln.UnderscoreLabelSanitization) {
+		return label, nil
+	}
+
 	normalizedName := sanitizeLabelName(label, ln.PreserveMultipleUnderscores)
 
 	// If label starts with a number, prepend with "key_".

--- a/label_namer_bench_test.go
+++ b/label_namer_bench_test.go
@@ -46,6 +46,10 @@ var labelBenchmarkInputs = []struct {
 		name:  "label starting with 2 underscores",
 		label: "__label_starting_with_2underscores",
 	},
+	{
+		name:  "reserved label",
+		label: "__reserved__label__name__",
+	},
 }
 
 func BenchmarkNormalizeLabel(b *testing.B) {

--- a/label_namer_bench_test.go
+++ b/label_namer_bench_test.go
@@ -11,6 +11,10 @@ var labelBenchmarkInputs = []struct {
 		label: "",
 	},
 	{
+		name:  "already-valid label",
+		label: "http_method_total",
+	},
+	{
 		name:  "label with colons",
 		label: "label:with:colons",
 	},
@@ -48,7 +52,8 @@ func BenchmarkNormalizeLabel(b *testing.B) {
 	labelNamer := LabelNamer{UTF8Allowed: false}
 	for _, input := range labelBenchmarkInputs {
 		b.Run(input.name, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			b.ReportAllocs()
+			for b.Loop() {
 				//nolint:errcheck
 				labelNamer.Build(input.label)
 			}

--- a/label_namer_test.go
+++ b/label_namer_test.go
@@ -40,6 +40,11 @@ var labelTestCases = []struct {
 		sanitizedMultipleUnderscores: "label_with_foreign_characters___",
 	},
 	{label: "label.with.dots", sanitized: "label_with_dots"},
+	{
+		label:                                ".foo",
+		sanitized:                            "_foo",
+		sanitizedUnderscoreLabelSanitization: "key_foo",
+	},
 	{label: "123label", sanitized: "key_123label"},
 	{
 		label:                                "_label_starting_with_underscore",
@@ -213,5 +218,72 @@ func TestBuildLabel_UTF8Allowed(t *testing.T) {
 				t.Errorf("LabelNamer.Build(%q) = %q, want %q", tt.label, got, tt.label)
 			}
 		})
+	}
+}
+
+// TestCanFastPathLabel verifies that the fast-path predicate agrees with
+// LabelNamer.Build across every entry in labelTestCases × the four configs.
+// Whenever canFastPathLabel returns true, Build must succeed and return the
+// input unchanged; whenever Build returns the input unchanged for a valid
+// input, canFastPathLabel must return true.
+func TestCanFastPathLabel(t *testing.T) {
+	configs := []struct {
+		name                        string
+		preserveMultipleUnderscores bool
+		underscoreLabelSanitization bool
+	}{
+		{"default", false, false},
+		{"preserve multiple underscores", true, false},
+		{"underscore label sanitization", false, true},
+		{"both", true, true},
+	}
+	for _, cfg := range configs {
+		t.Run(cfg.name, func(t *testing.T) {
+			for _, tt := range labelTestCases {
+				t.Run(tt.label, func(t *testing.T) {
+					if tt.label == "" {
+						return
+					}
+
+					namer := LabelNamer{
+						PreserveMultipleUnderscores: cfg.preserveMultipleUnderscores,
+						UnderscoreLabelSanitization: cfg.underscoreLabelSanitization,
+					}
+					got, err := namer.Build(tt.label)
+					fast := canFastPathLabel(tt.label, cfg.preserveMultipleUnderscores, cfg.underscoreLabelSanitization)
+
+					if fast {
+						if err != nil {
+							t.Fatalf("canFastPathLabel=true but Build returned error: %s", err)
+						}
+						if got != tt.label {
+							t.Fatalf("canFastPathLabel=true but Build returned %q, want input %q", got, tt.label)
+						}
+						return
+					}
+
+					// fast == false: nothing to assert about Build, except that if
+					// it succeeded with output equal to input, the predicate missed a
+					// no-op case (a false negative). False negatives are correct but
+					// suboptimal; we flag them so the predicate stays tight.
+					if err == nil && got == tt.label {
+						t.Fatalf("canFastPathLabel=false but Build returned input unchanged (false negative)")
+					}
+				})
+			}
+		})
+	}
+}
+
+// TestLabelNamerBuildZeroAlloc asserts that Build is allocation-free on the
+// fast path. The chosen input is already Prometheus-compliant; it must be
+// returned unchanged with no heap allocations.
+func TestLabelNamerBuildZeroAlloc(t *testing.T) {
+	namer := LabelNamer{}
+	got := testing.AllocsPerRun(100, func() {
+		_, _ = namer.Build("http_method_total")
+	})
+	if got > 0 {
+		t.Fatalf("Build allocated %f times per run on the fast path, want 0", got)
 	}
 }

--- a/strconv.go
+++ b/strconv.go
@@ -53,6 +53,9 @@ func sanitizeLabelName(name string, preserveMultipleUnderscores bool) string {
 	// Collapse multiple underscores while replacing invalid characters.
 	var b strings.Builder
 	b.Grow(nameLength)
+	if isReserved {
+		b.WriteString("__")
+	}
 	prevWasUnderscore := false
 
 	for _, r := range name {
@@ -66,7 +69,7 @@ func sanitizeLabelName(name string, preserveMultipleUnderscores bool) string {
 		}
 	}
 	if isReserved {
-		return "__" + b.String() + "__"
+		b.WriteString("__")
 	}
 	return b.String()
 }

--- a/strconv.go
+++ b/strconv.go
@@ -21,6 +21,7 @@ package otlptranslator
 
 import (
 	"strings"
+	"unicode"
 )
 
 // sanitizeLabelName replaces any characters not valid according to the
@@ -73,6 +74,55 @@ func sanitizeLabelName(name string, preserveMultipleUnderscores bool) string {
 // isValidCompliantLabelChar checks if a rune is a valid label name character (a-z, A-Z, 0-9).
 func isValidCompliantLabelChar(r rune) bool {
 	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')
+}
+
+// canFastPathLabel reports whether LabelNamer.Build would return label unchanged when UTF8Allowed is false.
+// When it returns true, the label can be returned directly. The predicate must remain
+// consistent with sanitizeLabelName and the post-sanitize prefix logic in LabelNamer.Build.
+func canFastPathLabel(label string, preserveMultipleUnderscores, underscoreLabelSanitization bool) bool {
+	n := len(label)
+	if n == 0 {
+		return false
+	}
+
+	// Leading digit triggers a "key_" prepend.
+	if unicode.IsDigit(rune(label[0])) {
+		return false
+	}
+	// Single leading '_' under sanitization triggers a "key" prepend.
+	if underscoreLabelSanitization && strings.HasPrefix(label, "_") && !strings.HasPrefix(label, "__") {
+		return false
+	}
+
+	// Reserved labels (__...__) under !preserveMultipleUnderscores get stripped,
+	// sanitized, then re-wrapped. The output equals the input iff the inner range
+	// already sanitizes to itself.
+	start, end := 0, n
+	if !preserveMultipleUnderscores && n >= 4 && strings.HasPrefix(label, "__") && strings.HasSuffix(label, "__") {
+		start, end = 2, n-2
+	}
+
+	prevWasUnderscore := false
+	sawNonUnderscore := false
+	for i := start; i < end; i++ {
+		c := label[i]
+		if !isValidCompliantLabelChar(rune(c)) && c != '_' {
+			// Non-ASCII bytes (lead/continuation of multi-byte runes) fall here.
+			return false
+		}
+		if c == '_' {
+			if !preserveMultipleUnderscores && prevWasUnderscore {
+				return false
+			}
+			prevWasUnderscore = true
+		} else {
+			prevWasUnderscore = false
+			sawNonUnderscore = true
+		}
+	}
+	// An all-underscore (or empty inner) result would hit Build's hasUnderscoresOnly
+	// error path; let the slow path produce the error.
+	return sawNonUnderscore
 }
 
 // isReservedLabel checks if a label is a reserved label.


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description". For example "LabelNamer: add Build method"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
Add a single forward-scan predicate `canFastPathLabel` that detects when `LabelNamer.Build` would return its input unchanged. On a hit, `Build` returns the input string directly with zero heap allocations, addressing the "already-compliant labels are wastefully reallocated" half of #68.

The predicate covers the four `LabelNamer` config combinations and the reserved-label round-trip (__...__) where the inner range sanitizes to itself. A property test asserts predicate-`Build` agreement across every case in `labelTestCases` × the four configs; `testing.AllocsPerRun` confirms the fast path is allocation-free.

Please note that there is one case that regresses in CPU utilization (+20.56%, ~18 ns): `NormalizeLabel/label_with_foreign_characters`. I think foreign characters in OTel metric attributes, while translation is enabled, should be an unusual case though, and the -30% geomean makes the tradeoff worth it.

I realized this simpler optimization could be made while reviewing #68.

```console
goos: darwin
goarch: arm64
pkg: github.com/prometheus/otlptranslator
cpu: Apple M4 Pro
                                                    │ /tmp/main_full.bench.txt │         /tmp/after.bench.txt         │
                                                    │          sec/op          │    sec/op     vs base                │
NormalizeLabel/empty_label-14                                      9.920n ± 3%    9.807n ± 2%        ~ (p=0.853 n=10)
NormalizeLabel/already-valid_label-14                              54.12n ± 3%    15.90n ± 1%  -70.62% (p=0.000 n=10)
NormalizeLabel/label_with_colons-14                                54.10n ± 1%    53.74n ± 1%        ~ (p=0.093 n=10)
NormalizeLabel/label_with_capital_letters-14                       68.88n ± 1%    17.58n ± 6%  -74.48% (p=0.000 n=10)
NormalizeLabel/label_with_special_characters-14                    79.08n ± 1%    73.98n ± 1%   -6.44% (p=0.000 n=10)
NormalizeLabel/label_with_foreign_characters-14                    89.62n ± 2%   108.05n ± 1%  +20.56% (p=0.000 n=10)
NormalizeLabel/label_with_dots-14                                  47.88n ± 1%    50.65n ± 1%   +5.80% (p=0.000 n=10)
NormalizeLabel/label_starting_with_digits-14                       42.02n ± 2%    42.28n ± 1%        ~ (p=0.239 n=10)
NormalizeLabel/label_starting_with_underscores-14                  98.92n ± 1%    25.93n ± 2%  -73.79% (p=0.000 n=10)
NormalizeLabel/label_starting_with_2_underscores-14               101.40n ± 1%    99.24n ± 1%   -2.13% (p=0.000 n=10)
NormalizeLabel/reserved_label-14                                   74.03n ± 1%    66.84n ± 1%   -9.71% (p=0.000 n=10)
geomean                                                            57.14n         40.12n       -29.78%

                                                    │ /tmp/main_full.bench.txt │          /tmp/after.bench.txt           │
                                                    │           B/op           │    B/op     vs base                     │
NormalizeLabel/empty_label-14                                       16.00 ± 0%   16.00 ± 0%         ~ (p=1.000 n=10) ¹
NormalizeLabel/already-valid_label-14                               24.00 ± 0%    0.00 ± 0%  -100.00% (p=0.000 n=10)
NormalizeLabel/label_with_colons-14                                 24.00 ± 0%   24.00 ± 0%         ~ (p=1.000 n=10) ¹
NormalizeLabel/label_with_capital_letters-14                        24.00 ± 0%    0.00 ± 0%  -100.00% (p=0.000 n=10)
NormalizeLabel/label_with_special_characters-14                     32.00 ± 0%   32.00 ± 0%         ~ (p=1.000 n=10) ¹
NormalizeLabel/label_with_foreign_characters-14                     48.00 ± 0%   48.00 ± 0%         ~ (p=1.000 n=10) ¹
NormalizeLabel/label_with_dots-14                                   16.00 ± 0%   16.00 ± 0%         ~ (p=1.000 n=10) ¹
NormalizeLabel/label_starting_with_digits-14                        24.00 ± 0%   24.00 ± 0%         ~ (p=1.000 n=10) ¹
NormalizeLabel/label_starting_with_underscores-14                   32.00 ± 0%    0.00 ± 0%  -100.00% (p=0.000 n=10)
NormalizeLabel/label_starting_with_2_underscores-14                 48.00 ± 0%   48.00 ± 0%         ~ (p=1.000 n=10) ¹
NormalizeLabel/reserved_label-14                                    56.00 ± 0%   32.00 ± 0%   -42.86% (p=0.000 n=10)
geomean                                                             28.78                    ?                       ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean

                                                    │ /tmp/main_full.bench.txt │          /tmp/after.bench.txt           │
                                                    │        allocs/op         │ allocs/op   vs base                     │
NormalizeLabel/empty_label-14                                       1.000 ± 0%   1.000 ± 0%         ~ (p=1.000 n=10) ¹
NormalizeLabel/already-valid_label-14                               1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
NormalizeLabel/label_with_colons-14                                 1.000 ± 0%   1.000 ± 0%         ~ (p=1.000 n=10) ¹
NormalizeLabel/label_with_capital_letters-14                        1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
NormalizeLabel/label_with_special_characters-14                     1.000 ± 0%   1.000 ± 0%         ~ (p=1.000 n=10) ¹
NormalizeLabel/label_with_foreign_characters-14                     1.000 ± 0%   1.000 ± 0%         ~ (p=1.000 n=10) ¹
NormalizeLabel/label_with_dots-14                                   1.000 ± 0%   1.000 ± 0%         ~ (p=1.000 n=10) ¹
NormalizeLabel/label_starting_with_digits-14                        2.000 ± 0%   2.000 ± 0%         ~ (p=1.000 n=10) ¹
NormalizeLabel/label_starting_with_underscores-14                   1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
NormalizeLabel/label_starting_with_2_underscores-14                 1.000 ± 0%   1.000 ± 0%         ~ (p=1.000 n=10) ¹
NormalizeLabel/reserved_label-14                                    2.000 ± 0%   1.000 ± 0%   -50.00% (p=0.000 n=10)
geomean                                                             1.134                    ?                       ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean
```