### PR TITLE
docs: fix incorrect godoc examples

### DIFF
--- a/label_namer.go
+++ b/label_namer.go
@@ -32,7 +32,11 @@ import (
 // Example usage:
 //
 //	namer := LabelNamer{UTF8Allowed: false}
-//	result := namer.Build("http.method") // "http_method"
+//	result, err := namer.Build("http.method")
+//	if err != nil {
+//		// handle err
+//	}
+//	// result == "http_method"
 type LabelNamer struct {
 	UTF8Allowed bool
 	// UnderscoreLabelSanitization, if true, enabled prepending 'key' to labels
@@ -52,7 +56,8 @@ type LabelNamer struct {
 //
 // Translation rules:
 //   - Replaces invalid characters with underscores
-//   - Prefixes labels with invalid start characters (numbers or `_`) with "key"
+//   - Prefixes labels starting with a digit with "key_"
+//   - With the deprecated UnderscoreLabelSanitization option, prefixes labels starting with a single underscore with "key"
 //   - Preserves double underscore labels (reserved names)
 //   - If UTF8Allowed is true, returns label as-is
 //

--- a/metric_namer.go
+++ b/metric_namer.go
@@ -95,7 +95,11 @@ var perUnitMap = map[string]string{
 //		Type: MetricTypeHistogram,
 //	}
 //
-//	result := namer.Build(metric) // "http_server_duration_seconds"
+//	result, err := namer.Build(metric)
+//	if err != nil {
+//		// handle err
+//	}
+//	// result == "http_server_duration_seconds"
 type MetricNamer struct {
 	Namespace          string
 	WithMetricSuffixes bool
@@ -143,11 +147,19 @@ type Metric struct {
 //
 //	// Counter gets _total suffix
 //	counter := Metric{Name: "requests.count", Unit: "1", Type: MetricTypeMonotonicCounter}
-//	result := namer.Build(counter) // "requests_count_total"
+//	result, err := namer.Build(counter)
+//	if err != nil {
+//		// handle err
+//	}
+//	// result == "requests_count_total"
 //
 //	// Gauge with unit suffix
 //	gauge := Metric{Name: "memory.usage", Unit: "By", Type: MetricTypeGauge}
-//	result = namer.Build(gauge) // "memory_usage_bytes"
+//	result, err = namer.Build(gauge)
+//	if err != nil {
+//		// handle err
+//	}
+//	// result == "memory_usage_bytes"
 func (mn *MetricNamer) Build(metric Metric) (string, error) {
 	if mn.UTF8Allowed {
 		return mn.buildMetricName(metric.Name, metric.Unit, metric.Type)


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description". For example "LabelNamer: add Build method"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
The `Build` examples in the godoc assigned the `(string, error)` return into a single variable, so they would not compile if copied from pkg.go.dev — the same defect already fixed in the README. Also correct the `LabelNamer.Build translation` rule that claimed a leading underscore is prefixed with "key": that only happens with the deprecated `UnderscoreLabelSanitization` option.

Follow-up to #72.