### PR TITLE
build: support Go 1.27 linting

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: 1.26.x
+          go-version: 1.27.x
       - name: Install snmp_exporter/generator dependencies
         run: sudo apt-get update && sudo apt-get -y install libsnmp-dev
         if: github.repository == 'prometheus/snmp_exporter'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,8 @@ formatters:
         - default
         - prefix(github.com/prometheus/otlptranslator)
     gofumpt:
-      extra-rules: true
+      extra:
+        group-params: true
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ FIRST_GOPATH := $(firstword $(subst :, ,$(shell $(GO) env GOPATH)))
 SKIP_GOLANGCI_LINT :=
 GOLANGCI_LINT :=
 GOLANGCI_LINT_OPTS ?=
-GOLANGCI_LINT_VERSION ?= v2.4.0
+GOLANGCI_LINT_VERSION ?= v2.13.1
 
 # golangci-lint only supports linux, darwin and windows platforms on i386/amd64/arm64.
 # windows isn't included here because of the path separator being different.


### PR DESCRIPTION
PR #86 synchronizes the lint workflow to Go 1.27, but this repository still selected golangci-lint v2.4.0, whose release binary was built with Go 1.25 and cannot read Go 1.27 export data.

This replacement carries the sync commit, updates golangci-lint to v2.13.1 to match the companion Prometheus Go 1.27 change, and migrates the deprecated gofumpt extra-rules setting to extra.group-params. The granular migration preserves the existing formatting contract and avoids unrelated Go source churn.

Replaces #86.